### PR TITLE
Fix undefined stacktrace variable when sending message

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,13 +117,13 @@ function errorDataCallback(data) {
     stacktrace.frames.forEach(frame => {
       frame.filename = normalizeUrl(frame.filename);
     });
+    // NOTE: the following block is the only difference between the upstream
+    // react-native-sentry error callback. It removes the empty stackframe "? at
+    // [native code]"" from the trace
+    let lastFrame = stacktrace.frames[0];
+    if (lastFrame.filename === '[native code]' && lastFrame.function === '?') {
+      stacktrace.frames.splice(0, 1);
+    }
   }
 
-  // NOTE: the following block is the only difference between the upstream
-  // react-native-sentry error callback. It removes the empty stackframe "? at
-  // [native code]"" from the trace
-  let lastFrame = stacktrace.frames[0];
-  if (lastFrame.filename === '[native code]' && lastFrame.function === '?') {
-    stacktrace.frames.splice(0, 1);
-  }
 }


### PR DESCRIPTION
This adds a check for the stacktrace var before trying to change it.

![img_4781](https://cloud.githubusercontent.com/assets/363802/26190609/a8f64326-3baa-11e7-9609-04027a5052e8.PNG)
