### PR TITLE
Bump react-native-sentry to 0.13.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,13 +117,13 @@ function errorDataCallback(data) {
     stacktrace.frames.forEach(frame => {
       frame.filename = normalizeUrl(frame.filename);
     });
+    // NOTE: the following block is the only difference between the upstream
+    // react-native-sentry error callback. It removes the empty stackframe "? at
+    // [native code]"" from the trace
+    let lastFrame = stacktrace.frames[0];
+    if (lastFrame.filename === '[native code]' && lastFrame.function === '?') {
+      stacktrace.frames.splice(0, 1);
+    }
   }
 
-  // NOTE: the following block is the only difference between the upstream
-  // react-native-sentry error callback. It removes the empty stackframe "? at
-  // [native code]"" from the trace
-  let lastFrame = stacktrace.frames[0];
-  if (lastFrame.filename === '[native code]' && lastFrame.function === '?') {
-    stacktrace.frames.splice(0, 1);
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-expo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@expo/spawn-async": "^1.2.8",
     "mkdirp": "^0.5.1",
-    "react-native-sentry": "https://github.com/expo/react-native-sentry/archive/expo-initial-release.tar.gz",
+    "react-native-sentry": "^0.13.0",
     "rimraf": "^2.6.1"
   }
 }

--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -39,7 +39,8 @@ module.exports = async options => {
       SENTRY_AUTH_TOKEN: config.authToken,
       SENTRY_URL: config.url || 'https://sentry.io/',
     });
-    let sentryCliBinary = '../sentry-cli-binary/bin/sentry-cli';
+
+    let sentryCliBinary = 'node_modules/sentry-cli-binary/bin/sentry-cli';
     let output;
     let createReleaseResult = await spawnAsync(
       sentryCliBinary,

--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -3,6 +3,7 @@ const path = require('path');
 const rimraf = require('rimraf');
 const mkdirp = require('mkdirp');
 const fs = require('fs');
+const sentryCliBinary = require('sentry-cli-binary');
 
 module.exports = async options => {
   let {
@@ -40,12 +41,12 @@ module.exports = async options => {
       SENTRY_URL: config.url || 'https://sentry.io/',
     });
 
-    const sentryCliBinary = path.resolve(projectRoot, 'node_modules', 'sentry-cli-binary', 'bin', 'sentry-cli')
-    log(sentryCliBinary);
+    const sentryCliBinaryPath = sentryCliBinary.getPath();
+    log(sentryCliBinaryPath);
 
     let output;
     let createReleaseResult = await spawnAsync(
-      sentryCliBinary,
+      sentryCliBinaryPath,
       ['releases', 'new', version],
       {
         cwd: tmpdir,
@@ -57,7 +58,7 @@ module.exports = async options => {
     log(output);
 
     let uploadResult = await spawnAsync(
-      sentryCliBinary,
+      sentryCliBinaryPath,
       [
         'releases',
         'files',

--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -37,11 +37,12 @@ module.exports = async options => {
       SENTRY_ORG: config.organization,
       SENTRY_PROJECT: config.project,
       SENTRY_AUTH_TOKEN: config.authToken,
+      SENTRY_URL: config.url || 'https://sentry.io/',
     });
-
+    let sentryCliBinary = '../sentry-cli-binary/bin/sentry-cli';
     let output;
     let createReleaseResult = await spawnAsync(
-      'sentry-cli',
+      sentryCliBinary,
       ['releases', 'new', version],
       {
         cwd: tmpdir,
@@ -53,7 +54,7 @@ module.exports = async options => {
     log(output);
 
     let uploadResult = await spawnAsync(
-      'sentry-cli',
+      sentryCliBinary,
       [
         'releases',
         'files',

--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -40,7 +40,9 @@ module.exports = async options => {
       SENTRY_URL: config.url || 'https://sentry.io/',
     });
 
-    let sentryCliBinary = 'node_modules/sentry-cli-binary/bin/sentry-cli';
+    const sentryCliBinary = path.resolve(tmpdir, 'node_modules', 'sentry-cli-binary', 'bin', 'sentry-cli')
+    log(sentryCliBinary);
+
     let output;
     let createReleaseResult = await spawnAsync(
       sentryCliBinary,

--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -40,7 +40,7 @@ module.exports = async options => {
       SENTRY_URL: config.url || 'https://sentry.io/',
     });
 
-    const sentryCliBinary = path.resolve(tmpdir, 'node_modules', 'sentry-cli-binary', 'bin', 'sentry-cli')
+    const sentryCliBinary = path.resolve(projectRoot, 'node_modules', 'sentry-cli-binary', 'bin', 'sentry-cli')
     log(sentryCliBinary);
 
     let output;


### PR DESCRIPTION
@brentvatne 
I've tested it with version 0.13 and it works.
I tried to add url as an additional `sentry-cli` parameter and tried using sentry-cli from `node_modules` without success.
Maybe you know why this is not working
Here is the log of the publish process:
```

13:21:49 Running postPublish hook: sentry-expo/upload-sourcemaps

13:21:50 /Users/haza/Desktop/bla/node_modules/sentry-cli-binary/bin/sentry-cli

Error: Process exited with non-zero code: 1
    at ChildProcess.child.on (/Users/haza/Desktop/bla/node_modules/@expo/spawn-async/build/spawnAsync.js:39:21)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:885:16)
    at Socket.<anonymous> (internal/child_process.js:334:11)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at Pipe._handle.close [as _onclose] (net.js:501:12)
```

But if I run `$ /Users/haza/Desktop/bla/node_modules/sentry-cli-binary/bin/sentry-cli`
sentry-cli is there.

If you get this to work, the documentation needs also a little adjustment.

*Consider squash merging it in the end*