### PR TITLE
Add option to install on dev

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import { Sentry } from 'react-native-sentry';
 export default Sentry;
 
 const originalSentryConfig = Sentry.config;
-Sentry.config = (dsn, options = {}) => {
+Sentry.config = (dsn, options = {}, skipDev = true) => {
   let defaultOptions = {
     tags: {
       ...(options.tags || {}),
@@ -19,7 +19,13 @@ Sentry.config = (dsn, options = {}) => {
   const release = Constants.manifest.revisionId || 'UNVERSIONED';
 
   // Bail out automatically if the app isn't deployed
-  if (release === 'UNVERSIONED') {
+  if (release === 'UNVERSIONED' && skipDev) {
+    const noop = () => {};
+    Object.getOwnPropertyNames(Sentry).forEach((prop) => {
+      if (typeof Sentry[prop] === 'function') {
+        Sentry[prop] = noop;
+      }
+    });
     return {
       install: () => {
         console.log('Automatically skipping Sentry initialization in development');

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import { Sentry } from 'react-native-sentry';
 export default Sentry;
 
 const originalSentryConfig = Sentry.config;
-Sentry.config = (dsn, options = {}, skipDev = true) => {
+Sentry.config = (dsn, options = {}) => {
   let defaultOptions = {
     tags: {
       ...(options.tags || {}),
@@ -19,7 +19,7 @@ Sentry.config = (dsn, options = {}, skipDev = true) => {
   const release = Constants.manifest.revisionId || 'UNVERSIONED';
 
   // Bail out automatically if the app isn't deployed
-  if (release === 'UNVERSIONED' && skipDev) {
+  if (release === 'UNVERSIONED' && !Sentry.enableInExpoDevelopment) {
     const noop = () => {};
     Object.getOwnPropertyNames(Sentry).forEach((prop) => {
       if (typeof Sentry[prop] === 'function') {


### PR DESCRIPTION
Added an extra parameter to `config` which enables installing on dev environments. Also added code to swap all Sentry class methods with `noop`s, which fixes #9.