### PR TITLE
Better DX (fix hot reload, better log)

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,13 @@ Sentry.config = (dsn, options = {}) => {
         Sentry[prop] = noop;
       }
     });
-    return {
-      install: () => {
-        console.log('Automatically skipping Sentry initialization in development');
-      },
+    console.log('[sentry-expo] Automatically skipping Sentry initialization in development. Note you can set Sentry.enableInExpoDevelopment=true before calling Sentry.config(...).install()');
+    const replacedConfigReturn = {
+      install: noop,
     };
+    // Ensure Sentry.config().install() do not throw on hot-reload if Sentry.enableInExpoDevelopment=false
+    Sentry.config = () => replacedConfigReturn;
+    return replacedConfigReturn;
   }
 
   return originalSentryConfig(dsn, { ...defaultOptions, ...options, release });


### PR DESCRIPTION
I've spent some time figuring out why my integration did not work.

I think it's worth documenting the `Sentry.enableInExpoDevelopment=true` attribute because I actually expected this to work in dev too.

Also worth mentioning that if we set Sentry.config = noop like it did, in case someone does hot reload the code and it calls `Sentry.config().install()` again, it produces "can't call install() on undefined" errors due to hot reload. My code fixes this issue as it replaces config fn with a better mock in case Sentry is supposed to be disabled. Also notice it ensures that on hot reload we only log once.
