### PR TITLE
Update sentry react native to `0.36.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@expo/spawn-async": "^1.2.8",
     "mkdirp": "^0.5.1",
-    "react-native-sentry": "^0.30.0",
+    "react-native-sentry": "^0.36.0",
     "rimraf": "^2.6.1"
   }
 }

--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -3,7 +3,7 @@ const path = require('path');
 const rimraf = require('rimraf');
 const mkdirp = require('mkdirp');
 const fs = require('fs');
-const sentryCliBinary = require('sentry-cli-binary');
+const sentryCliBinary = require('@sentry/cli');
 
 module.exports = async options => {
   let {


### PR DESCRIPTION
We have an issue where the `@sentry/cli` [package is incompatible](https://github.com/getsentry/sentry-cli/issues/227) with the [standard Docker linux distro Alpine](https://www.reddit.com/r/linux/comments/44e0k2/docker_official_images_are_moving_to_alpine_linux/). In the latest version of this cli package they added an option to use a custom CDN for prebuilt binaries. With this we can work around the incompatibility issue. It might be wise to just update to the latest version to include this ability and other fixes from the repo.