### PR TITLE
Modify version being used to label Sentry releases

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ Sentry.config = (dsn, options = {}) => {
     },
   };
 
-  const release = Constants.manifest.revisionId || 'UNVERSIONED';
+  const release = Constants.manifest.version || 'UNVERSIONED';
 
   // Bail out automatically if the app isn't deployed
   if (release === 'UNVERSIONED' && !Sentry.enableInExpoDevelopment) {

--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -23,7 +23,7 @@ module.exports = async options => {
 
   // revisionId is the same between the Android and IOS manifests, so
   // we just pick one and get on with it.
-  const version = iosManifest.revisionId;
+  const version = iosManifest.version;
 
   rimraf.sync(tmpdir);
   mkdirp.sync(tmpdir);


### PR DESCRIPTION
Made the version used for tracking Sentry releases consistent with the version in Expo's `app.json`.