### PR TITLE
fix "Using Sentry" docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # sentry-expo
 
 Read about how to use this in the Expo docs, ["Using
-Sentry"](https://docs.expo.io/versions/latest/guides/using-sentry.html).
+Sentry"](https://docs.expo.io/versions/latest/guides/using-sentry/).


### PR DESCRIPTION
Link is broken, fixing url suffix from ".html" to "/"