### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@expo/spawn-async": "^1.2.8",
     "mkdirp": "^0.5.1",
-    "react-native-sentry": "^0.40.2",
+    "react-native-sentry": "^0.42.0",
     "rimraf": "^2.6.1"
   }
 }


### PR DESCRIPTION
Updating sentry-expo to use latest version of react-native-sentry (version 0.42.0)