### PR TITLE
get config from env

### DIFF
--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -35,10 +35,10 @@ module.exports = async options => {
     fs.writeFileSync(tmpdir + '/main.android.map', androidSourceMap, 'utf-8');
 
     const childProcessEnv = Object.assign({}, process.env, {
-      SENTRY_ORG: config.organization,
-      SENTRY_PROJECT: config.project,
+      SENTRY_ORG: config.organization || process.env.SENTRY_ORG,
+      SENTRY_PROJECT: config.project || process.env.SENTRY_PROJECT,
       SENTRY_AUTH_TOKEN: config.authToken || process.env.SENTRY_AUTH_TOKEN,
-      SENTRY_URL: config.url || 'https://sentry.io/',
+      SENTRY_URL: config.url || process.env.SENTRY_URL || 'https://sentry.io/',
     });
 
     const sentryCliBinaryPath = config.useGlobalSentryCli ?


### PR DESCRIPTION
# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

I try to run 
`
export publish
`

and got the error
`
Running postPublish hook: sentry-expo/upload-sourcemaps
Error uploading sourcemaps to Sentry: API request failed
caused by: sentry reported an error: Invalid token (http status: 401)
`

After checking the log using 
`
SENTRY_LOG_LEVEL=debug
`

it is making a request to https://sentry.io/
`
DEBUG   2019-04-15 11:15:55.558481 +08:00 request POST https://sentry.io/api/0/projects/sentry/projectname/releases/
DEBUG   2019-04-15 11:15:56.354348 +08:00 > Host: sentry.io
`

It is not retrieving the host from process.env.SENTRY_URL

Adding url in postPublish config post to the right host. 
It should also be able to retrieve host from environment variables in .env

# Related PR

Refer to https://github.com/expo/expo/pull/3990