### PR TITLE
Change to use the new expo-constants unimodule

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { Constants } from 'expo';
+import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 import { Sentry } from 'react-native-sentry';
 export default Sentry;


### PR DESCRIPTION
This change requires SDK 33 but will remove the warning about deprecation when using this package with SDK 33.