### PR TITLE
fix(ts): add `enableInExpoDevelopment` to typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,8 @@
-export * from "@sentry/react-native";
+import { ReactNativeOptions } from '@sentry/react-native';
+export * from '@sentry/react-native';
+
+export interface ExpoOptions extends ReactNativeOptions {
+  enableInExpoDevelopment?: boolean;
+}
+
+export function init(options: ExpoOptions): void;


### PR DESCRIPTION
See https://github.com/expo/sentry-expo/pull/58#discussion_r323226432