### PR TITLE
Modify the deviceId tag to come from installationId instead of deviceId

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ class ExpoIntegration {
     });
 
     Sentry.setTags({
-      deviceId: Constants.deviceId,
+      deviceId: Constants.installationId,
       appOwnership: Constants.appOwnership,
       expoVersion: Constants.expoVersion,
     });


### PR DESCRIPTION
Since Constants.deviceId is just an alias for Constants.installationId, I thought that tag may as well come from installationId.