### PR TITLE
feat: Allow setting version via Env var

### DIFF
--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -23,7 +23,7 @@ module.exports = async options => {
 
   // revisionId is the same between the Android and IOS manifests, so
   // we just pick one and get on with it.
-  const version = iosManifest.revisionId;
+  const version = process.env.SENTRY_VERSION || iosManifest.revisionId;
 
   rimraf.sync(tmpdir);
   mkdirp.sync(tmpdir);


### PR DESCRIPTION
Use case is where we're already creating releases via sentry-cli, but we want the post-publish hook (as getting sourcemaps otherwise seem to be an issue and this was made to resolve it judging from https://github.com/expo/expo-cli/issues/298), and need the files to be associated with the originally created release, for the sourcemaps to work properly.

Creating a new release with an existing version via sentry-cli seems to be a no-op, so lines 49-56 are fine to stay as is.