### PR TITLE
fix(upload): strip projectRoot from sourcemaps

### DIFF
--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -71,6 +71,8 @@ module.exports = async options => {
         '--ext',
         'map',
         '--rewrite',
+        '--strip-prefix',
+        projectRoot,
       ],
       {
         cwd: tmpdir,


### PR DESCRIPTION
Adding `--strip-prefix ${projectRoot}` to "remove a path that is build machine specific" as described in [Upload Source Maps](https://docs.sentry.io/cli/releases/#sentry-cli-sourcemaps).

This improves sentry issue display by rendering something like `Error onPress(screens/MyScreen)` instead of `Error onPress(/Users/builder/project/screens/MyScreen)` given `/Users/builder/project/` is the projectRoot.

closes #37