### PR TITLE
fix: remove devicename

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,6 @@ class ExpoIntegration {
         event.contexts = {
           ...(event.contexts || {}),
           device: {
-            deviceName: Constants.deviceName,
             simulator: !Constants.isDevice,
             ...additionalDeviceInformation,
           },


### PR DESCRIPTION
closes https://github.com/expo/sentry-expo/issues/93

device name doesn't give much help in terms of bug reporting or troubleshooting, so removing it by default