### PR TITLE
feat: ability to set commits and deploys in sourcemaps hook

### DIFF
--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -82,8 +82,7 @@ module.exports = async (options) => {
     output = uploadResult.stdout.toString();
     log(output);
 
-    setCommits = setCommits || process.env.SENTRY_EXPO_SET_COMMITS;
-    if (setCommits) {
+    if (setCommits || process.env.SENTRY_EXPO_SET_COMMITS) {
       let commitsResult = await spawnAsync(
         sentryCliBinaryPath,
         ['releases', 'set-commits', '--auto', version],
@@ -96,6 +95,17 @@ module.exports = async (options) => {
       log(output);
     }
 
+    let finalizeReleaseResult = await spawnAsync(
+      sentryCliBinaryPath,
+      ['releases', 'finalize', version],
+      {
+        env: childProcessEnv,
+      }
+    );
+
+    output = finalizeReleaseResult.stdout.toString();
+    log(output);
+
     deployEnv = deployEnv || process.env.SENTRY_EXPO_DEPLOY_ENV;
     if (deployEnv) {
       let deployResult = await spawnAsync(
@@ -106,7 +116,8 @@ module.exports = async (options) => {
         }
       )
 
-      output = deployResult.stdout.toString();
+      // filter out unnamed deloy
+      output = deployResult.stdout.toString().replace('unnamed ', '');
       log(output);
     }
 


### PR DESCRIPTION
Closes #88.

I'm sorry it took so long to open this PR 🤦 .

I went ahead and also added the ability to set [`deploys`](https://docs.sentry.io/workflow/releases/?platform=javascript#create-deploy) too. 

Configuration is as follows with the postPublish `config` attribute.
```json
{
  "postPublish": [
      {
        "file": "sentry-expo/upload-sourcemaps",
        "config": {
          "setCommits": true,
          "deployEnv": "production"
        }
      }
  ]
}
```

Or, it can be configured with environment vars (this could be easier than changing up app.json on the fly

```
SENTRY_EXPO_SET_COMMITS=true
SENTRY_EXPO_DEPLOY_ENV=production
```

`setCommits` must be `"true"` or `true` for it to run, and `deployEnv` needs to be any non empty string.