### PR TITLE
feat: set release in config or env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,12 +136,14 @@ export const init = (options = {}) => {
     }),
   ];
 
-  const release = !!Constants.manifest
-    ? Constants.manifest.revisionId || 'UNVERSIONED'
-    : Date.now();
+  if (!options.release) {
+    options.release = !!Constants.manifest
+      ? Constants.manifest.revisionId || 'UNVERSIONED'
+      : Date.now();
+  }
 
   // Bail out automatically if the app isn't deployed
-  if (release === 'UNVERSIONED' && !options.enableInExpoDevelopment) {
+  if (options.release === 'UNVERSIONED' && !options.enableInExpoDevelopment) {
     options.enabled = false;
     console.log(
       '[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });'
@@ -151,5 +153,5 @@ export const init = (options = {}) => {
   // We don't want to have the native nagger.
   options.enableNativeNagger = false;
   options.enableNative = false;
-  return originalSentryInit({ ...options, release });
+  return originalSentryInit({ ...options });
 };


### PR DESCRIPTION
this is pretty much a copy of @jtomaszewski's PR

closes https://github.com/expo/sentry-expo/pull/89
closes https://github.com/expo/sentry-expo/pull/111

allows you to set the `release` to whatever you want, not forced into using `revisionId`

You can do this by setting the `SENTRY_RELEASE` env var before publishing, or setting `release` in the postPublish hook config. Note that you should set the `release` field to the same value in your call to `Sentry.init` (probably works best to have this be set to the env variable)