### PR TITLE
[WIP] add sentry-expo integration for bare workflow

### DIFF
--- a/index.expo.js
+++ b/index.expo.js
@@ -1,0 +1,165 @@
+/* @flow */
+export * from '@sentry/react-native';
+import Constants from 'expo-constants';
+import { Platform } from 'react-native';
+import * as Sentry from '@sentry/react-native';
+import { RewriteFrames } from '@sentry/integrations';
+
+/**
+ * Expo bundles are hosted on cloudfront. Expo bundle filename will change
+ * at some point in the future in order to be able to delete this code.
+ */
+function isPublishedExpoUrl(url) {
+  return url.includes('https://d1wp6m56sqw74a.cloudfront.net');
+}
+
+function normalizeUrl(url) {
+  if (isPublishedExpoUrl(url)) {
+    return `app:///main.${Platform.OS}.bundle`;
+  } else {
+    return url;
+  }
+}
+
+class ExpoIntegration {
+  static id = 'ExpoIntegration';
+  name = ExpoIntegration.id;
+
+  setupOnce() {
+    Sentry.setExtras({
+      manifest: Constants.manifest,
+      deviceYearClass: Constants.deviceYearClass,
+      linkingUri: Constants.linkingUri,
+    });
+
+    Sentry.setTags({
+      deviceId: Constants.installationId,
+      appOwnership: Constants.appOwnership,
+      expoVersion: Constants.expoVersion,
+    });
+
+    if (!!Constants.manifest) {
+      if (Constants.manifest.releaseChannel) {
+        Sentry.setTag('expoReleaseChannel', Constants.manifest.releaseChannel);
+      }
+      if (Constants.manifest.version) {
+        Sentry.setTag('expoAppVersion', Constants.manifest.version);
+      }
+      if (Constants.manifest.publishedTime) {
+        Sentry.setTag('expoAppPublishedTime', Constants.manifest.publishedTime);
+      }
+    }
+
+    if (Constants.sdkVersion) {
+      Sentry.setTag('expoSdkVersion', Constants.sdkVersion);
+    }
+
+    const defaultHandler =
+      (ErrorUtils.getGlobalHandler && ErrorUtils.getGlobalHandler()) || ErrorUtils._globalHandler;
+
+    ErrorUtils.setGlobalHandler((error, isFatal) => {
+      // On Android, the Expo bundle filepath cannot be handled by TraceKit,
+      // so we normalize it to use the same filepath that we use on Expo iOS.
+      if (Platform.OS === 'android') {
+        error.stack = error.stack.replace(
+          /\/.*\/\d+\.\d+.\d+\/cached\-bundle\-experience\-/g,
+          'https://d1wp6m56sqw74a.cloudfront.net:443/'
+        );
+      }
+
+      Sentry.getCurrentHub().withScope(scope => {
+        if (isFatal) {
+          scope.setLevel(Sentry.Severity.Fatal);
+        }
+        Sentry.getCurrentHub().captureException(error, {
+          originalException: error,
+        });
+      });
+
+      const client = Sentry.getCurrentHub().getClient();
+      // If in dev, we call the default handler anyway and hope the error will be sent
+      // Just for a better dev experience
+      if (client && !__DEV__) {
+        client
+          .flush(client.getOptions().shutdownTimeout || 2000)
+          .then(() => {
+            defaultHandler(error, isFatal);
+          })
+          .catch(e => {
+            logger.error(e);
+          });
+      } else {
+        // If there is no client something is fishy, anyway we call the default handler
+        defaultHandler(error, isFatal);
+      }
+    });
+
+    Sentry.addGlobalEventProcessor(function(event, hint) {
+      var that = Sentry.getCurrentHub().getIntegration(ExpoIntegration);
+
+      if (that) {
+        let additionalDeviceInformation = {};
+
+        if (Platform.OS === 'ios') {
+          additionalDeviceInformation = {
+            model: Constants.platform.ios.model,
+          };
+        } else {
+          additionalDeviceInformation = {
+            model: 'n/a',
+          };
+        }
+
+        event.contexts = {
+          ...(event.contexts || {}),
+          device: {
+            simulator: !Constants.isDevice,
+            ...additionalDeviceInformation,
+          },
+          os: {
+            name: Platform.OS === 'ios' ? 'iOS' : 'Android',
+            version: `${Platform.Version}`,
+          },
+        };
+      }
+
+      return event;
+    });
+  }
+}
+
+const originalSentryInit = Sentry.init;
+export const init = (options = {}) => {
+  options.integrations = [
+    ...(options.integrations || []),
+    new Sentry.Integrations.ReactNativeErrorHandlers({
+      onerror: false,
+      onunhandledrejection: true,
+    }),
+    new ExpoIntegration(),
+    new RewriteFrames({
+      iteratee: frame => {
+        if (frame.filename) {
+          frame.filename = normalizeUrl(frame.filename);
+        }
+        return frame;
+      },
+    }),
+  ];
+
+  const release = !!Constants.manifest
+    ? Constants.manifest.revisionId || 'UNVERSIONED'
+    : Date.now();
+
+  // Bail out automatically if the app isn't deployed
+  if (release === 'UNVERSIONED' && !options.enableInExpoDevelopment) {
+    options.enabled = false;
+    console.log(
+      '[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });'
+    );
+  }
+
+  // We don't want to have the native nagger.
+  options.enableNativeNagger = false;
+  return originalSentryInit({ ...options, release });
+};

--- a/index.js
+++ b/index.js
@@ -3,156 +3,123 @@ export * from '@sentry/react-native';
 import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 import * as Sentry from '@sentry/react-native';
-import { RewriteFrames } from '@sentry/integrations';
+import * as Updates from 'expo-updates';
 
-/**
- * Expo bundles are hosted on cloudfront. Expo bundle filename will change
- * at some point in the future in order to be able to delete this code.
- */
-function isPublishedExpoUrl(url) {
-  return url.includes('https://d1wp6m56sqw74a.cloudfront.net');
-}
+function setupSentryExpo() {
+  Sentry.setExtras({
+    manifest: Updates.manifest,
+    deviceYearClass: Constants.deviceYearClass,
+  });
 
-function normalizeUrl(url) {
-  if (isPublishedExpoUrl(url)) {
-    return `app:///main.${Platform.OS}.bundle`;
-  } else {
-    return url;
+  Sentry.setTags({
+    deviceId: Constants.installationId,
+  });
+
+  if (Updates.updateId) {
+    Sentry.setTag('expoUpdateId', Updates.updateId);
   }
-}
+  if (Updates.releaseChannel) {
+    Sentry.setTag('expoReleaseChannel', Updates.releaseChannel);
+  }
 
-class ExpoIntegration {
-  static id = 'ExpoIntegration';
-  name = ExpoIntegration.id;
-
-  setupOnce() {
-    Sentry.setExtras({
-      manifest: Constants.manifest,
-      deviceYearClass: Constants.deviceYearClass,
-      linkingUri: Constants.linkingUri,
-    });
-
-    Sentry.setTags({
-      deviceId: Constants.installationId,
-      appOwnership: Constants.appOwnership,
-      expoVersion: Constants.expoVersion,
-    });
-
-    if (!!Constants.manifest) {
-      if (Constants.manifest.releaseChannel) {
-        Sentry.setTag('expoReleaseChannel', Constants.manifest.releaseChannel);
-      }
-      if (Constants.manifest.version) {
-        Sentry.setTag('expoAppVersion', Constants.manifest.version);
-      }
-      if (Constants.manifest.publishedTime) {
-        Sentry.setTag('expoAppPublishedTime', Constants.manifest.publishedTime);
-      }
+  if (!!Updates.manifest) {
+    if (Updates.manifest.version) {
+      Sentry.setTag('expoAppVersion', Updates.manifest.version);
     }
-
-    if (Constants.sdkVersion) {
-      Sentry.setTag('expoSdkVersion', Constants.sdkVersion);
+    if (Updates.manifest.publishedTime) {
+      Sentry.setTag('expoAppPublishedTime', Updates.manifest.publishedTime);
     }
+    if (Updates.manifest.sdkVersion) {
+      Sentry.setTag('expoSdkVersion', Updates.manifest.sdkVersion);
+    }
+  }
 
-    const defaultHandler =
-      (ErrorUtils.getGlobalHandler && ErrorUtils.getGlobalHandler()) || ErrorUtils._globalHandler;
+  const defaultHandler =
+    (ErrorUtils.getGlobalHandler && ErrorUtils.getGlobalHandler()) || ErrorUtils._globalHandler;
 
-    ErrorUtils.setGlobalHandler((error, isFatal) => {
-      // On Android, the Expo bundle filepath cannot be handled by TraceKit,
-      // so we normalize it to use the same filepath that we use on Expo iOS.
-      if (Platform.OS === 'android') {
-        error.stack = error.stack.replace(
-          /\/.*\/\d+\.\d+.\d+\/cached\-bundle\-experience\-/g,
-          'https://d1wp6m56sqw74a.cloudfront.net:443/'
-        );
+  ErrorUtils.setGlobalHandler((error, isFatal) => {
+    // Updates bundle names are not predictable in advance, so we replace them with the names
+    // Sentry expects to be in the stacktrace.
+    // The name of the sourcemap file in Sentry is different depending on whether it was uploaded
+    // by the upload-sourcemaps script in this package (in which case it will have a revisionId)
+    // or by the default @sentry/react-native script.
+    let sentryFilename;
+    if (Updates.manifest.revisionId) {
+      sentryFilename = `main.${Platform.OS}.bundle`;
+    } else {
+      sentryFilename = Platform.OS === 'android' ? 'index.android.bundle' : 'main.jsbundle';
+    }
+    error.stack = error.stack.replace(/\/(bundle\-\d+|[\dabcdef]+\.bundle)/g, `/${sentryFilename}`);
+
+    Sentry.getCurrentHub().withScope((scope) => {
+      if (isFatal) {
+        scope.setLevel(Sentry.Severity.Fatal);
       }
-
-      Sentry.getCurrentHub().withScope(scope => {
-        if (isFatal) {
-          scope.setLevel(Sentry.Severity.Fatal);
-        }
-        Sentry.getCurrentHub().captureException(error, {
-          originalException: error,
-        });
+      Sentry.getCurrentHub().captureException(error, {
+        originalException: error,
       });
-
-      const client = Sentry.getCurrentHub().getClient();
-      // If in dev, we call the default handler anyway and hope the error will be sent
-      // Just for a better dev experience
-      if (client && !__DEV__) {
-        client
-          .flush(client.getOptions().shutdownTimeout || 2000)
-          .then(() => {
-            defaultHandler(error, isFatal);
-          })
-          .catch(e => {
-            logger.error(e);
-          });
-      } else {
-        // If there is no client something is fishy, anyway we call the default handler
-        defaultHandler(error, isFatal);
-      }
     });
 
-    Sentry.addGlobalEventProcessor(function(event, hint) {
-      var that = Sentry.getCurrentHub().getIntegration(ExpoIntegration);
+    const client = Sentry.getCurrentHub().getClient();
+    // If in dev, we call the default handler anyway and hope the error will be sent
+    // Just for a better dev experience
+    if (client && !__DEV__) {
+      client
+        .flush(client.getOptions().shutdownTimeout || 2000)
+        .then(() => {
+          defaultHandler(error, isFatal);
+        })
+        .catch((e) => {
+          logger.error(e);
+        });
+    } else {
+      // If there is no client something is fishy, anyway we call the default handler
+      defaultHandler(error, isFatal);
+    }
+  });
 
-      if (that) {
-        let additionalDeviceInformation = {};
+  Sentry.addGlobalEventProcessor(function (event, hint) {
+    let additionalDeviceInformation = {};
 
-        if (Platform.OS === 'ios') {
+      if (Platform.OS === 'ios') {
+        if (Constants.platform && Constants.platform.ios) {
           additionalDeviceInformation = {
             model: Constants.platform.ios.model,
           };
-        } else {
-          additionalDeviceInformation = {
-            model: 'n/a',
-          };
         }
-
-        event.contexts = {
-          ...(event.contexts || {}),
-          device: {
-            simulator: !Constants.isDevice,
-            ...additionalDeviceInformation,
-          },
-          os: {
-            name: Platform.OS === 'ios' ? 'iOS' : 'Android',
-            version: `${Platform.Version}`,
-          },
+      } else {
+        additionalDeviceInformation = {
+          model: 'n/a',
         };
       }
 
-      return event;
-    });
-  }
+      event.contexts = {
+        ...(event.contexts || {}),
+        device: {
+          simulator: !Constants.isDevice,
+          ...additionalDeviceInformation,
+        },
+        os: {
+          name: Platform.OS === 'ios' ? 'iOS' : 'Android',
+          version: `${Platform.Version}`,
+        },
+      };
+
+    return event;
+  });
 }
 
 const originalSentryInit = Sentry.init;
 export const init = (options = {}) => {
-  options.integrations = [
-    ...(options.integrations || []),
-    new Sentry.Integrations.ReactNativeErrorHandlers({
-      onerror: false,
-      onunhandledrejection: true,
-    }),
-    new ExpoIntegration(),
-    new RewriteFrames({
-      iteratee: frame => {
-        if (frame.filename) {
-          frame.filename = normalizeUrl(frame.filename);
-        }
-        return frame;
-      },
-    }),
-  ];
-
-  const release = !!Constants.manifest
-    ? Constants.manifest.revisionId || 'UNVERSIONED'
-    : Date.now();
+  const release = Updates.manifest.revisionId;
+  // if there's no revisionId, we are using an embedded bundle and should use the release
+  // that Sentry automatically sets
+  if (release) {
+    options.release = release;
+  }
 
   // Bail out automatically if the app isn't deployed
-  if (release === 'UNVERSIONED' && !options.enableInExpoDevelopment) {
+  if (!release && !options.enableInExpoDevelopment) {
     options.enabled = false;
     console.log(
       '[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });'
@@ -161,5 +128,14 @@ export const init = (options = {}) => {
 
   // We don't want to have the native nagger.
   options.enableNativeNagger = false;
-  return originalSentryInit({ ...options, release });
+  const returnValue = originalSentryInit({ ...options });
+
+  // NOTE(2020-05-27): Sentry currently has an issue where the native iOS SDK and the JS SDK expect
+  // `options.integrations` to be in different formats -- the iOS SDK expects an array of strings,
+  // while the JS SDK expects an array of `Integration` objects. To avoid this catch-22 for now,
+  // we're not creating an `ExpoIntegration` and instead just running all of the setup in this
+  // `init` method.
+  setupSentryExpo();
+
+  return returnValue;
 };

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "license": "MIT",
   "dependencies": {
     "@expo/spawn-async": "^1.2.8",
-    "expo-constants": "*",
     "@sentry/integrations": "^5.5.0",
     "@sentry/react-native": "^1.0.0",
+    "expo-constants": "*",
+    "expo-updates": "^0.2.4",
     "mkdirp": "^1.0.3",
+    "properties-reader": "^2.0.0",
     "rimraf": "^2.6.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,6 +166,11 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -275,6 +280,11 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -297,6 +307,13 @@ decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
 
 end-of-stream@^1.1.0:
   version "1.4.1"
@@ -342,6 +359,14 @@ expo-constants@*:
   dependencies:
     ua-parser-js "^0.7.19"
 
+expo-updates@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-0.2.4.tgz#dfb195b0873cee5a7165e85b574a0b6a877098a3"
+  integrity sha512-YW4cA2hLTsflZDoY/Lrnpxp11cxrK3h58CQHl9XpGAOvKul8TVU2moewiZ2Mrn9QrJmW18jJgss4cemrDNmmNQ==
+  dependencies:
+    fbemitter "^2.1.1"
+    uuid "^3.4.0"
+
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -350,6 +375,26 @@ external-editor@^3.0.3:
     chardet "^0.7.0"
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
+
+fbemitter@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fbemitter/-/fbemitter-2.1.1.tgz#523e14fdaf5248805bb02f62efc33be703f51865"
+  integrity sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=
+  dependencies:
+    fbjs "^0.8.4"
+
+fbjs@^0.8.4:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -412,7 +457,7 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
-iconv-lite@^0.4.24:
+iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -473,7 +518,7 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -492,6 +537,19 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
+
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 lcid@^2.0.0:
   version "2.0.0"
@@ -512,6 +570,13 @@ lodash@^4.17.11, lodash@^4.17.12:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+loose-envify@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -551,6 +616,11 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -562,6 +632,13 @@ mkdirp@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
   integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
+
+mkdirp@~0.5.1:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
 
 ms@^2.1.1:
   version "2.1.2"
@@ -577,6 +654,14 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-fetch@^2.0.0-alpha.8, node-fetch@^2.1.2:
   version "2.6.0"
@@ -594,6 +679,11 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
+object-assign@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -693,6 +783,20 @@ progress@2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
   integrity sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
+properties-reader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/properties-reader/-/properties-reader-2.0.0.tgz#04ddfe3a9a5d00275f457666bc60faafa01c2273"
+  integrity sha512-wEvznelF2vGq52VA51j8ZNoUZOeCJQd2kh5CGHLOhdLKKN176ZAdYv+WH6s6tj7IOBLFRkWhMPQjq8uzyFe37Q==
+  dependencies:
+    mkdirp "~0.5.1"
+
 proxy-from-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
@@ -775,6 +879,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -881,6 +990,11 @@ typedarray-to-buffer@^3.1.2:
   dependencies:
     is-typedarray "^1.0.0"
 
+ua-parser-js@^0.7.18:
+  version "0.7.21"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
+  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+
 ua-parser-js@^0.7.19:
   version "0.7.20"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
@@ -890,6 +1004,16 @@ uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+whatwg-fetch@>=0.10.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Working on adding a better sentry integration for expo-updates in the bare workflow. This is still WIP but I wanted to get something open (& see if anyone else has any input/ideas!).

This is tricky because we have two possible sources of JS bundles -- they can be embedded in the IPA/APK (in which case the source maps need to be uploaded at build-time) or downloaded as an OTA update (in which case the source maps need to be uploaded at publish-time).

I have been going for a hybrid approach that uses both the official Sentry RN integration for embedded bundles, and the existing sentry-expo setup for OTA updates. Currently the steps are:

- Install and setup sentry's native RN integration (which includes sourcemap uploads) as for any RN project, following their [setup guide](https://docs.sentry.io/platforms/react-native/) (using the wizard is great!)
- Install sentry-expo (no need to add app.json keys, upload-sourcemaps now reads from sentry.properties)
- Import from sentry-expo and use as usual

Behind the scenes, I moved index.js to index.expo.js for the managed workflow, and introduced a new index.js for the bare workflow -- the purpose (and much of the code) is similar but is customized for the bare workflow, where the bundle filenames are different and there are different constants available. The idea is that the Sentry RN setup takes care of uploading the sourcemaps for embedded bundles during the build process, and sentry-expo's upload-sourcemaps script will do it for published bundles.

The issues I'm currently running into are:

1) The `options.integrations` field in `Sentry.init` does not play well with the native iOS Sentry library. It seems that the iOS Sentry library expects the entries in `options.integrations` to be strings, and an NSException is thrown if they are not strings. However, the JS Sentry library expects them to be `Integration` objects. It is not clear to me if this is a bug/oversight in Sentry or something I'm doing wrong. But this forced me to abandon the approach of using `ExpoIntegration` like in index.expo.js, and instead just run the setup code manually.
2) In my test project with the code on this branch, JS errors that cause the app to crash are not getting reported to Sentry. My understanding of how this works is that it logs the error to disk somewhere and sends to Sentry the next time the app launches. I've verified this works on managed workflow projects but it seems that Sentry is not catching these errors on bare workflow projects. It's possible(?) that this is because I'm unable to add any `integrations` such as the `ReactNativeErrorHandlers` integration.