### PR TITLE
export uploadSourcemaps hook from root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add the `expo.hooks` object to your project's `app.json` (or `app.config`) file:
     "hooks": {
       "postPublish": [
         {
-          "file": "sentry-expo/dist/upload-sourcemaps",
+          "file": "sentry-expo/upload-sourcemaps",
           "config": {
             "organization": "your sentry organization's short name here",
             "project": "your sentry project's name here",

--- a/upload-sourcemaps.js
+++ b/upload-sourcemaps.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/upload-sourcemaps');


### PR DESCRIPTION
@byCedric pointed out that we could do this and avoid causing a breaking change (now or in the future) for users in their app.json configuration 🙌 