### PR TITLE
chore: add simple build ci to test package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,5 +27,9 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile --check-files --ignore-scripts
+      - name: Clean build
+        run: rm -rf dist
       - name: Build package
         run: yarn build
+      - name: Build up-to-date
+        run: git diff --exit-code dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+---
+name: Build package
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Find cache
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --check-files --ignore-scripts
+      - name: Build package
+        run: yarn build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Build package
         run: yarn build
       - name: Build up-to-date
-        run: git diff --exit-code dist
+        run: git diff --stat --exit-code dist


### PR DESCRIPTION
~~This adds a plain CI to avoid issues, like the one we have now with `string | undefined is not assignable to string`.~~

> Edit, looks like it was something local. Maybe I accidentally upgraded some dependencies. Nonetheless, I think it's good to have this.

We can also add this step to check if `dist` is up to date. It's a simple script to detect changes in the `dist` folder and exit with an error if there are. It does not detect additional files though. I've used this one in [`expo/expo-github-action`](https://github.com/expo/expo-github-action/blob/master/.circleci/config.yml#L17).

```
- name: Build up-to-date
  run: git diff --stat --exit-code dist
```

An alternative to _detect_ deleted files would be to remove the `dist` folder before building. And then running the check listed above. 😄 