### PR TITLE
fix: more bare workflow sourcemap fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   const { Transports } = Browser;
   ```
 
+- The iOS sourcemap files' names were changed from `main.ios.bundle` and `main.ios.map` to `main.jsbundle` and `main.jsbundle.map`, respectively. This matches the filenames created in the bare workflow during [no publish builds](https://github.com/expo/sentry-expo#configure-no-publish-builds). This only affects you if you were manually generating & uploading sourcemaps to Sentry, rather than relying on `expo publish` or `expo export`. [#129](https://github.com/expo/sentry-expo/pull/129)
+
+- The Android sourcemap files' names were changed from `main.android.bundle` and `main.android.map` to `index.android.bundle` and `index.android.bundle.map`, respectively. This matches the filenames created in the bare workflow during [no publish builds](https://github.com/expo/sentry-expo#configure-no-publish-builds). This only affects you if you were manually generating & uploading sourcemaps to Sentry, rather than relying on `expo publish` or `expo export`. [#130](https://github.com/expo/sentry-expo/pull/130)
+
 ### 🎉 New features
 
 - Expo Web support: no changes needed!

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ to your root project file (usually `App.js`), so make sure you remove it (but ke
 
 #### Configure "no publish builds"
 
-With `expo-updates`, release builds of both iOS and Android apps will create and embed a new update from your JavaScript source at build-time. **This new update will not be published automatically** and will exist only in the binary with which it was bundled. Since it isn't published, the sourcemaps aren't uploaded in the usual way like they are when you run `expo publish` (actually, we are relying on Sentry's native scripts to handle that). Because of this you have some extra things to add:
+With `expo-updates`, release builds of both iOS and Android apps will create and embed a new update from your JavaScript source at build-time. **This new update will not be published automatically** and will exist only in the binary with which it was bundled. Since it isn't published, the sourcemaps aren't uploaded in the usual way like they are when you run `expo publish` (actually, we are relying on Sentry's native scripts to handle that). Because of this you have some extra things to be aware of:
 
-- Set your `release` in `Sentry.init()` to Sentry's expected value- `${bundleIdentifier}@${version}+${buildNumber}` (iOS) or `${androidPackage}@${version}+${versionCode}` (Android).
-- Set your `dist` in Sentry.init()` to Sentry's expected value: your buildNumber (iOS) or versionCode (Android).
+- Your `release` will automatically be set to Sentry's expected value- `${bundleIdentifier}@${version}+${buildNumber}` (iOS) or `${androidPackage}@${version}+${versionCode}` (Android).
+- Your `dist` will automatically be set to Sentry's expected value- `${buildNumber}` (iOS) or `${versionCode}` (Android).
 - The configuration for build time sourcemaps comes from the `ios/sentry.properties` and `android/sentry.properties` files. For more information, refer to [Sentry's documentation](https://docs.sentry.io/clients/java/config/#configuration-via-properties-file).
 
 > Please note that configuration for `expo publish` and `expo export` is still done via `app.json`.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ With `expo-updates`, release builds of both iOS and Android apps will create and
 
 Skipping or misconfiguring either of these will result in sourcemaps not working, and thus you won't see proper stacktraces in your errors.
 
+> **Note**: There seems to be a [possible bug with `sentry-react-native`](https://github.com/getsentry/sentry-react-native/issues/761) which results in Android sourcemaps not working appropriately. If you run into this issue in the bare workflow, something that seems to help remedy the issue is setting the release (using `Sentry.Native.setRelease`) _after_ running `Sentry.init`.
+
 ## 👏 Contributing
 
 If you like `sentry-expo` and want to help make it better then please feel free to open a PR! Make sure you request a review from one of our maintainers 😎

--- a/dist/hooks/upload-sourcemaps.js
+++ b/dist/hooks/upload-sourcemaps.js
@@ -60,8 +60,8 @@ module.exports = function (options) { return __awaiter(void 0, void 0, void 0, f
                 // We use the same filenames for sourcemaps as Sentry does (even though the naming is unfortunate)
                 fs_1.default.writeFileSync(tmpdir + '/main.jsbundle', iosBundle, 'utf-8');
                 fs_1.default.writeFileSync(tmpdir + '/main.jsbundle.map', iosSourceMap, 'utf-8');
-                fs_1.default.writeFileSync(tmpdir + '/main.android.bundle', androidBundle, 'utf-8');
-                fs_1.default.writeFileSync(tmpdir + '/main.android.map', androidSourceMap, 'utf-8');
+                fs_1.default.writeFileSync(tmpdir + '/index.android.bundle', androidBundle, 'utf-8');
+                fs_1.default.writeFileSync(tmpdir + '/index.android.bundle.map', androidSourceMap, 'utf-8');
                 organization = void 0, project = void 0, authToken = void 0, url = void 0, useGlobalSentryCli = void 0, release = void 0, setCommits = void 0, deployEnv = void 0;
                 if (!config) {
                     log('No config found in app.json, falling back to environment variables...');

--- a/dist/integrations/bare.js
+++ b/dist/integrations/bare.js
@@ -53,11 +53,7 @@ var ExpoIntegration = /** @class */ (function () {
         });
         react_native_2.setTags({
             deviceId: expo_constants_1.default.installationId,
-            appOwnership: expo_constants_1.default.appOwnership,
         });
-        if (expo_constants_1.default.appOwnership === 'expo' && expo_constants_1.default.expoVersion) {
-            react_native_2.setTag('expoAppVersion', expo_constants_1.default.expoVersion);
-        }
         if (manifest) {
             react_native_2.setTag('expoReleaseChannel', manifest.releaseChannel);
             react_native_2.setTag('appVersion', (_a = manifest.version) !== null && _a !== void 0 ? _a : '');

--- a/dist/integrations/bare.js
+++ b/dist/integrations/bare.js
@@ -72,12 +72,7 @@ var ExpoIntegration = /** @class */ (function () {
             // by the upload-sourcemaps script in this package (in which case it will have a revisionId)
             // or by the default @sentry/react-native script.
             var sentryFilename;
-            if (manifest.revisionId) {
-                sentryFilename = "main." + react_native_1.Platform.OS + ".bundle";
-            }
-            else {
-                sentryFilename = react_native_1.Platform.OS === 'android' ? 'index.android.bundle' : 'main.jsbundle';
-            }
+            sentryFilename = react_native_1.Platform.OS === 'android' ? 'index.android.bundle' : 'main.jsbundle';
             error.stack = error.stack.replace(/\/(bundle\-\d+|[\dabcdef]+\.bundle)/g, "/" + sentryFilename);
             react_native_2.getCurrentHub().withScope(function (scope) {
                 if (isFatal) {

--- a/dist/sentry.expo.js
+++ b/dist/sentry.expo.js
@@ -91,7 +91,7 @@ function isPublishedExpoUrl(url) {
 }
 function normalizeUrl(url) {
     if (isPublishedExpoUrl(url)) {
-        return "app:///main." + react_native_1.Platform.OS + ".bundle";
+        return react_native_1.Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
     }
     else {
         return url;

--- a/dist/sentry.js
+++ b/dist/sentry.js
@@ -53,7 +53,6 @@ var utils_1 = require("./utils");
 exports.init = function (options) {
     var _a;
     if (options === void 0) { options = {}; }
-    alert('sentry.ts file');
     if (react_native_1.Platform.OS === 'web') {
         return browser_1.init(__assign(__assign({}, options), { enabled: __DEV__ ? (_a = options.enableInExpoDevelopment) !== null && _a !== void 0 ? _a : false : true }));
     }

--- a/dist/sentry.js
+++ b/dist/sentry.js
@@ -66,8 +66,7 @@ exports.init = function (options) {
         new integrations_1.RewriteFrames({
             iteratee: function (frame) {
                 if (frame.filename) {
-                    frame.filename =
-                        react_native_1.Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
+                    frame.filename = react_native_1.Platform.OS === 'android' ? '~/index.android.bundle' : '~/main.jsbundle';
                 }
                 return frame;
             },
@@ -98,7 +97,8 @@ exports.init = function (options) {
         nativeOptions.enabled = false;
         console.log('[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });');
     }
-    if (!nativeOptions.dist) {
+    // Check if build-time update
+    if (!nativeOptions.dist && !manifest.revisionId) {
         nativeOptions.dist = expo_constants_1.default.nativeBuildVersion || '';
     }
     return react_native_2.init(__assign({}, nativeOptions));

--- a/dist/sentry.js
+++ b/dist/sentry.js
@@ -36,10 +36,15 @@ var __spreadArrays = (this && this.__spreadArrays) || function () {
             r[k] = a[j];
     return r;
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.init = void 0;
 var react_native_1 = require("react-native");
 var Updates = __importStar(require("expo-updates"));
+var expo_constants_1 = __importDefault(require("expo-constants"));
+var Application = __importStar(require("expo-application"));
 var browser_1 = require("@sentry/browser");
 var integrations_1 = require("@sentry/integrations");
 var react_native_2 = require("@sentry/react-native");
@@ -48,6 +53,7 @@ var utils_1 = require("./utils");
 exports.init = function (options) {
     var _a;
     if (options === void 0) { options = {}; }
+    alert('sentry.ts file');
     if (react_native_1.Platform.OS === 'web') {
         return browser_1.init(__assign(__assign({}, options), { enabled: __DEV__ ? (_a = options.enableInExpoDevelopment) !== null && _a !== void 0 ? _a : false : true }));
     }
@@ -61,7 +67,8 @@ exports.init = function (options) {
         new integrations_1.RewriteFrames({
             iteratee: function (frame) {
                 if (frame.filename) {
-                    frame.filename = react_native_1.Platform.OS === 'android' ? '~/index.android.bundle' : '~/main.jsbundle';
+                    frame.filename =
+                        react_native_1.Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
                 }
                 return frame;
             },
@@ -83,13 +90,17 @@ exports.init = function (options) {
     else {
         nativeOptions.integrations = __spreadArrays(defaultExpoIntegrations);
     }
-    if (!nativeOptions.release && manifest.revisionId) {
-        nativeOptions.release = manifest.revisionId;
+    if (!nativeOptions.release) {
+        var defaultSentryReleaseName = Application.applicationId + "@" + Application.nativeApplicationVersion + "+" + Application.nativeBuildVersion;
+        nativeOptions.release = manifest.revisionId ? manifest.revisionId : defaultSentryReleaseName;
     }
     // Bail out automatically if the app isn't deployed
     if (!manifest.revisionId && !nativeOptions.enableInExpoDevelopment) {
         nativeOptions.enabled = false;
         console.log('[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });');
+    }
+    if (!nativeOptions.dist) {
+        nativeOptions.dist = expo_constants_1.default.nativeBuildVersion || '';
     }
     return react_native_2.init(__assign({}, nativeOptions));
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@sentry/integrations": "^5.15.5",
     "@sentry/react-native": "1.4.2",
     "@sentry/types": "^5.17.0",
+    "expo-application": "^2.2.1",
     "expo-constants": "*",
     "expo-device": "*",
     "expo-updates": "^0.2.4",

--- a/src/hooks/upload-sourcemaps.ts
+++ b/src/hooks/upload-sourcemaps.ts
@@ -46,8 +46,8 @@ module.exports = async (options: Options) => {
     // We use the same filenames for sourcemaps as Sentry does (even though the naming is unfortunate)
     fs.writeFileSync(tmpdir + '/main.jsbundle', iosBundle, 'utf-8');
     fs.writeFileSync(tmpdir + '/main.jsbundle.map', iosSourceMap, 'utf-8');
-    fs.writeFileSync(tmpdir + '/main.android.bundle', androidBundle, 'utf-8');
-    fs.writeFileSync(tmpdir + '/main.android.map', androidSourceMap, 'utf-8');
+    fs.writeFileSync(tmpdir + '/index.android.bundle', androidBundle, 'utf-8');
+    fs.writeFileSync(tmpdir + '/index.android.bundle.map', androidSourceMap, 'utf-8');
 
     let organization, project, authToken, url, useGlobalSentryCli, release, setCommits, deployEnv;
     if (!config) {

--- a/src/integrations/bare.ts
+++ b/src/integrations/bare.ts
@@ -25,12 +25,7 @@ export class ExpoIntegration {
 
     setTags({
       deviceId: Constants.installationId,
-      appOwnership: Constants.appOwnership,
     });
-
-    if (Constants.appOwnership === 'expo' && Constants.expoVersion) {
-      setTag('expoAppVersion', Constants.expoVersion);
-    }
 
     if (manifest) {
       setTag('expoReleaseChannel', manifest.releaseChannel);

--- a/src/integrations/bare.ts
+++ b/src/integrations/bare.ts
@@ -49,11 +49,8 @@ export class ExpoIntegration {
       // or by the default @sentry/react-native script.
       let sentryFilename;
 
-      if (manifest.revisionId) {
-        sentryFilename = `main.${Platform.OS}.bundle`;
-      } else {
-        sentryFilename = Platform.OS === 'android' ? 'index.android.bundle' : 'main.jsbundle';
-      }
+      sentryFilename = Platform.OS === 'android' ? 'index.android.bundle' : 'main.jsbundle';
+
       error.stack = error.stack.replace(
         /\/(bundle\-\d+|[\dabcdef]+\.bundle)/g,
         `/${sentryFilename}`

--- a/src/sentry.expo.ts
+++ b/src/sentry.expo.ts
@@ -5,7 +5,11 @@ import { RewriteFrames } from '@sentry/integrations';
 import { init as initNative, Integrations } from '@sentry/react-native';
 import { Integration } from '@sentry/types';
 import { ExpoIntegration } from './integrations/managed';
-import { overrideDefaultIntegrations, SentryExpoNativeOptions, SentryExpoWebOptions } from './utils';
+import {
+  overrideDefaultIntegrations,
+  SentryExpoNativeOptions,
+  SentryExpoWebOptions,
+} from './utils';
 
 export const init = (options: SentryExpoNativeOptions | SentryExpoWebOptions = {}) => {
   if (Platform.OS === 'web') {
@@ -83,7 +87,7 @@ function isPublishedExpoUrl(url: string) {
 
 function normalizeUrl(url: string) {
   if (isPublishedExpoUrl(url)) {
-    return `app:///main.${Platform.OS}.bundle`;
+    return Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
   } else {
     return url;
   }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -14,7 +14,6 @@ import {
 } from './utils';
 
 export const init = (options: SentryExpoNativeOptions | SentryExpoWebOptions = {}) => {
-  alert('sentry.ts file');
   if (Platform.OS === 'web') {
     return initBrowser({
       ...(options as SentryExpoWebOptions),

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -31,8 +31,7 @@ export const init = (options: SentryExpoNativeOptions | SentryExpoWebOptions = {
     new RewriteFrames({
       iteratee: (frame) => {
         if (frame.filename) {
-          frame.filename =
-            Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
+          frame.filename = Platform.OS === 'android' ? '~/index.android.bundle' : '~/main.jsbundle';
         }
         return frame;
       },
@@ -73,7 +72,8 @@ export const init = (options: SentryExpoNativeOptions | SentryExpoWebOptions = {
     );
   }
 
-  if (!nativeOptions.dist) {
+  // Check if build-time update
+  if (!nativeOptions.dist && !manifest.revisionId) {
     nativeOptions.dist = Constants.nativeBuildVersion || '';
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,6 +375,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+expo-application@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/expo-application/-/expo-application-2.2.1.tgz#f14b83ae0b07e4922850f8856a56f141c168d6d0"
+  integrity sha512-YyYB2EPWmFmXgmnul9AMdZ6Ze290BWaez7RhUfAMq2gQU84EdpvL3vkO9SV5E4zI7Rj2jfS0VcCDpxrcdlBW/w==
+
 expo-constants@*:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-9.0.0.tgz#35c600079ee91d38fe4f56375caae6e90f122fdd"


### PR DESCRIPTION
After the [last PR](https://github.com/expo/sentry-expo/pull/129), I realized there was more to do:

- set `release` and `dist` automatically in bare to what sentry expects (less work for user / things to remember)
- change names of android sourcemap files to match Sentry's expected values
  - updated the changelog with breaking change for anyone manually uploading sourcemaps
- Fix logic for changing the name of sourcemapped files in bare (this makes the two integrations very similar, we could probably make it one file now)
- fix expected file names in multiple places

This has been tested on android and ios in both bare and managed workflows