### PR TITLE
fix: Tags with invalid values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
   )
   ```
 
+- Fixed tags with invalid values. ([#137](https://github.com/expo/sentry-expo/pull/137) by [@RodolfoGS](https://github.com/RodolfoGS))
+
 ## 2.1.2 — 2020-06-05
 
 - pin `@sentry/react-native` to v1.4.2 to prevent native calls

--- a/dist/integrations/bare.js
+++ b/dist/integrations/bare.js
@@ -54,7 +54,7 @@ var ExpoIntegration = /** @class */ (function () {
         react_native_2.setTags({
             deviceId: expo_constants_1.default.installationId,
         });
-        if (manifest) {
+        if (!!manifest && Object.keys(manifest).length > 0) {
             react_native_2.setTag('expoReleaseChannel', manifest.releaseChannel);
             react_native_2.setTag('appVersion', (_a = manifest.version) !== null && _a !== void 0 ? _a : '');
             react_native_2.setTag('appPublishedTime', manifest.publishedTime);

--- a/dist/integrations/bare.js
+++ b/dist/integrations/bare.js
@@ -39,26 +39,48 @@ var expo_constants_1 = __importDefault(require("expo-constants"));
 var Device = __importStar(require("expo-device"));
 var Updates = __importStar(require("expo-updates"));
 var react_native_2 = require("@sentry/react-native");
+var DEFAULT_EXTRAS = ['deviceYearClass', 'linkingUri'];
+var DEFAULT_TAGS = [
+    {
+        tagName: 'expoReleaseChannel',
+        manifestName: 'releaseChannel',
+    },
+    {
+        tagName: 'appVersion',
+        manifestName: 'version',
+    },
+    {
+        tagName: 'appPublishedTime',
+        manifestName: 'publishedTime',
+    },
+    {
+        tagName: 'expoSdkVersion',
+        manifestName: 'sdkVersion',
+    },
+];
 var ExpoIntegration = /** @class */ (function () {
     function ExpoIntegration() {
         this.name = ExpoIntegration.id;
     }
     ExpoIntegration.prototype.setupOnce = function () {
-        var _a, _b;
         var manifest = Updates.manifest;
         react_native_2.setExtras({
             manifest: manifest,
-            deviceYearClass: expo_constants_1.default.deviceYearClass,
-            linkingUri: expo_constants_1.default.linkingUri,
+        });
+        DEFAULT_EXTRAS.forEach(function (extra) {
+            if (expo_constants_1.default.hasOwnProperty(extra)) {
+                react_native_2.setExtra(extra, expo_constants_1.default[extra]);
+            }
         });
         react_native_2.setTags({
             deviceId: expo_constants_1.default.installationId,
         });
-        if (!!manifest && Object.keys(manifest).length > 0) {
-            react_native_2.setTag('expoReleaseChannel', manifest.releaseChannel);
-            react_native_2.setTag('appVersion', (_a = manifest.version) !== null && _a !== void 0 ? _a : '');
-            react_native_2.setTag('appPublishedTime', manifest.publishedTime);
-            react_native_2.setTag('expoSdkVersion', (_b = manifest.sdkVersion) !== null && _b !== void 0 ? _b : '');
+        if (typeof manifest === 'object') {
+            DEFAULT_TAGS.forEach(function (tag) {
+                if (manifest.hasOwnProperty(tag.manifestName)) {
+                    react_native_2.setTag(tag.tagName, manifest[tag.manifestName]);
+                }
+            });
         }
         var defaultHandler = ErrorUtils.getGlobalHandler();
         ErrorUtils.setGlobalHandler(function (error, isFatal) {

--- a/dist/integrations/managed.js
+++ b/dist/integrations/managed.js
@@ -38,17 +38,38 @@ var react_native_1 = require("react-native");
 var expo_constants_1 = __importDefault(require("expo-constants"));
 var Device = __importStar(require("expo-device"));
 var react_native_2 = require("@sentry/react-native");
+var DEFAULT_EXTRAS = ['deviceYearClass', 'linkingUri'];
+var DEFAULT_TAGS = [
+    {
+        tagName: 'expoReleaseChannel',
+        manifestName: 'releaseChannel',
+    },
+    {
+        tagName: 'appVersion',
+        manifestName: 'version',
+    },
+    {
+        tagName: 'appPublishedTime',
+        manifestName: 'publishedTime',
+    },
+    {
+        tagName: 'expoSdkVersion',
+        manifestName: 'sdkVersion',
+    },
+];
 var ExpoIntegration = /** @class */ (function () {
     function ExpoIntegration() {
         this.name = ExpoIntegration.id;
     }
     ExpoIntegration.prototype.setupOnce = function () {
-        var _a, _b;
         var manifest = expo_constants_1.default.manifest;
         react_native_2.setExtras({
             manifest: manifest,
-            deviceYearClass: expo_constants_1.default.deviceYearClass,
-            linkingUri: expo_constants_1.default.linkingUri,
+        });
+        DEFAULT_EXTRAS.forEach(function (extra) {
+            if (expo_constants_1.default.hasOwnProperty(extra)) {
+                react_native_2.setExtra(extra, expo_constants_1.default[extra]);
+            }
         });
         react_native_2.setTags({
             deviceId: expo_constants_1.default.installationId,
@@ -57,11 +78,12 @@ var ExpoIntegration = /** @class */ (function () {
         if (expo_constants_1.default.appOwnership === 'expo' && expo_constants_1.default.expoVersion) {
             react_native_2.setTag('expoAppVersion', expo_constants_1.default.expoVersion);
         }
-        if (!!manifest && Object.keys(manifest).length > 0) {
-            react_native_2.setTag('expoReleaseChannel', manifest.releaseChannel || 'N/A');
-            react_native_2.setTag('appVersion', (_a = manifest.version) !== null && _a !== void 0 ? _a : '');
-            react_native_2.setTag('appPublishedTime', manifest.publishedTime);
-            react_native_2.setTag('expoSdkVersion', (_b = manifest.sdkVersion) !== null && _b !== void 0 ? _b : '');
+        if (typeof manifest === 'object') {
+            DEFAULT_TAGS.forEach(function (tag) {
+                if (manifest.hasOwnProperty(tag.manifestName)) {
+                    react_native_2.setTag(tag.tagName, manifest[tag.manifestName]);
+                }
+            });
         }
         var defaultHandler = ErrorUtils.getGlobalHandler();
         ErrorUtils.setGlobalHandler(function (error, isFatal) {

--- a/dist/integrations/managed.js
+++ b/dist/integrations/managed.js
@@ -57,7 +57,7 @@ var ExpoIntegration = /** @class */ (function () {
         if (expo_constants_1.default.appOwnership === 'expo' && expo_constants_1.default.expoVersion) {
             react_native_2.setTag('expoAppVersion', expo_constants_1.default.expoVersion);
         }
-        if (!!manifest) {
+        if (!!manifest && Object.keys(manifest).length > 0) {
             react_native_2.setTag('expoReleaseChannel', manifest.releaseChannel || 'N/A');
             react_native_2.setTag('appVersion', (_a = manifest.version) !== null && _a !== void 0 ? _a : '');
             react_native_2.setTag('appPublishedTime', manifest.publishedTime);

--- a/src/integrations/bare.ts
+++ b/src/integrations/bare.ts
@@ -7,31 +7,59 @@ import {
   setTags,
   getCurrentHub,
   Severity,
+  setExtra,
   setTag,
   addGlobalEventProcessor,
 } from '@sentry/react-native';
+
+const DEFAULT_EXTRAS = ['deviceYearClass', 'linkingUri'];
+
+const DEFAULT_TAGS = [
+  {
+    tagName: 'expoReleaseChannel',
+    manifestName: 'releaseChannel',
+  },
+  {
+    tagName: 'appVersion',
+    manifestName: 'version',
+  },
+  {
+    tagName: 'appPublishedTime',
+    manifestName: 'publishedTime',
+  },
+  {
+    tagName: 'expoSdkVersion',
+    manifestName: 'sdkVersion',
+  },
+];
 
 export class ExpoIntegration {
   static id = 'ExpoIntegration';
   name = ExpoIntegration.id;
 
   setupOnce() {
-    let manifest = Updates.manifest as any;
+    const manifest = Updates.manifest as any;
+
     setExtras({
-      manifest: manifest,
-      deviceYearClass: Constants.deviceYearClass,
-      linkingUri: Constants.linkingUri,
+      manifest,
+    });
+
+    DEFAULT_EXTRAS.forEach(extra => {
+      if (Constants.hasOwnProperty(extra)) {
+        setExtra(extra, Constants[extra]);
+      }
     });
 
     setTags({
       deviceId: Constants.installationId,
     });
 
-    if (!!manifest && Object.keys(manifest).length > 0) {
-      setTag('expoReleaseChannel', manifest.releaseChannel);
-      setTag('appVersion', manifest.version ?? '');
-      setTag('appPublishedTime', manifest.publishedTime);
-      setTag('expoSdkVersion', manifest.sdkVersion ?? '');
+    if (typeof manifest === 'object') {
+      DEFAULT_TAGS.forEach(tag => {
+        if (manifest.hasOwnProperty(tag.manifestName)) {
+          setTag(tag.tagName, manifest[tag.manifestName]);
+        }
+      });
     }
 
     const defaultHandler = ErrorUtils.getGlobalHandler();

--- a/src/integrations/bare.ts
+++ b/src/integrations/bare.ts
@@ -27,7 +27,7 @@ export class ExpoIntegration {
       deviceId: Constants.installationId,
     });
 
-    if (manifest) {
+    if (!!manifest && Object.keys(manifest).length > 0) {
       setTag('expoReleaseChannel', manifest.releaseChannel);
       setTag('appVersion', manifest.version ?? '');
       setTag('appPublishedTime', manifest.publishedTime);

--- a/src/integrations/managed.ts
+++ b/src/integrations/managed.ts
@@ -31,7 +31,7 @@ export class ExpoIntegration {
       setTag('expoAppVersion', Constants.expoVersion);
     }
 
-    if (!!manifest) {
+    if (!!manifest && Object.keys(manifest).length > 0) {
       setTag('expoReleaseChannel', manifest.releaseChannel || 'N/A');
       setTag('appVersion', manifest.version ?? '');
       setTag('appPublishedTime', manifest.publishedTime);

--- a/src/integrations/managed.ts
+++ b/src/integrations/managed.ts
@@ -6,20 +6,47 @@ import {
   setTags,
   getCurrentHub,
   Severity,
+  setExtra,
   setTag,
   addGlobalEventProcessor,
 } from '@sentry/react-native';
+
+const DEFAULT_EXTRAS = ['deviceYearClass', 'linkingUri'];
+
+const DEFAULT_TAGS = [
+  {
+    tagName: 'expoReleaseChannel',
+    manifestName: 'releaseChannel',
+  },
+  {
+    tagName: 'appVersion',
+    manifestName: 'version',
+  },
+  {
+    tagName: 'appPublishedTime',
+    manifestName: 'publishedTime',
+  },
+  {
+    tagName: 'expoSdkVersion',
+    manifestName: 'sdkVersion',
+  },
+];
 
 export class ExpoIntegration {
   static id = 'ExpoIntegration';
   name = ExpoIntegration.id;
 
   setupOnce() {
-    let manifest = Constants.manifest;
+    const manifest = Constants.manifest;
+
     setExtras({
-      manifest: manifest,
-      deviceYearClass: Constants.deviceYearClass,
-      linkingUri: Constants.linkingUri,
+      manifest,
+    });
+
+    DEFAULT_EXTRAS.forEach(extra => {
+      if (Constants.hasOwnProperty(extra)) {
+        setExtra(extra, Constants[extra]);
+      }
     });
 
     setTags({
@@ -31,11 +58,12 @@ export class ExpoIntegration {
       setTag('expoAppVersion', Constants.expoVersion);
     }
 
-    if (!!manifest && Object.keys(manifest).length > 0) {
-      setTag('expoReleaseChannel', manifest.releaseChannel || 'N/A');
-      setTag('appVersion', manifest.version ?? '');
-      setTag('appPublishedTime', manifest.publishedTime);
-      setTag('expoSdkVersion', manifest.sdkVersion ?? '');
+    if (typeof manifest === 'object') {
+      DEFAULT_TAGS.forEach(tag => {
+        if (manifest.hasOwnProperty(tag.manifestName)) {
+          setTag(tag.tagName, manifest[tag.manifestName]);
+        }
+      });
     }
 
     const defaultHandler = ErrorUtils.getGlobalHandler();


### PR DESCRIPTION
# Why

Fixes: https://github.com/expo/sentry-expo/issues/138

When you run the app and send a crash the follow error appears on Sentry:

![image](https://user-images.githubusercontent.com/870365/89443445-e71ddb00-d715-11ea-96e5-d2aaba733c0d.png)

This happen because `manifest` is an empty object.