### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "expo-application": "^2.2.1",
     "expo-constants": "*",
     "expo-device": "*",
-    "expo-updates": "~0.3.0",
+    "expo-updates": "~0.3.5",
     "mkdirp": "^1.0.3",
     "rimraf": "^2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "expo-application": "^2.2.1",
     "expo-constants": "*",
     "expo-device": "*",
-    "expo-updates": "^0.2.4",
+    "expo-updates": "~0.3.0",
     "mkdirp": "^1.0.3",
     "rimraf": "^2.6.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,10 +1551,10 @@ expo-device@*:
     fbjs "1.0.0"
     ua-parser-js "^0.7.19"
 
-expo-updates@^0.2.4:
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-0.2.14.tgz#0cfbab6ebb8560b1955d888a7d4a31c643e7f3fd"
-  integrity sha512-/FNEDRSS7xxG+ql/vDdjPD6eAG63K9zbXsinYsu9Nrm06OhbB8MAx+OA4bMn+CZkvrQOzVJMhZ3oPvyOvEcmuQ==
+expo-updates@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-0.3.5.tgz#cd9aafeb5cbe16399df7d39243d00d330d99e674"
+  integrity sha512-O+W0MfDZPhhCYKFtLL85ifd+YAm3rFKALWzmyKOSGBb/L+8CBPQsbbB3mdvji0V2NCqq0+jrBvSCmNa5LRD41w==
   dependencies:
     "@expo/metro-config" "^0.1.16"
     fbemitter "^2.1.1"


### PR DESCRIPTION
Currently getting a warning after `npx pod-install` with 
```
Found some duplicated unimodule packages. Installed the ones with the highest version number.
Make sure following dependencies of your project are resolving to one specific version:
 expo-updates
```
When using 
```
"sentry-expo": "^3.0.2",
"expo-updates": "^0.3.5",
```