### PR TITLE
Use explicitly passed dist in options

### DIFF
--- a/dist/sentry.js
+++ b/dist/sentry.js
@@ -95,9 +95,14 @@ exports.init = function (options) {
         console.log('[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });');
     }
     // Check if build-time update
-    nativeOptions.dist =
-        nativeOptions.dist || manifest.revisionId
-            ? manifest.version
-            : "" + expo_constants_1.default.nativeBuildVersion;
+    if (!nativeOptions.dist) {
+        // if the dist is already explicitly passed in, use that, otherwise:
+        if (manifest.revisionId) {
+            nativeOptions.dist = manifest.version;
+        }
+        else {
+            nativeOptions.dist = "" + expo_constants_1.default.nativeBuildVersion;
+        }
+    }
     return react_native_2.init(__assign({}, nativeOptions));
 };

--- a/dist/sentry.js
+++ b/dist/sentry.js
@@ -96,7 +96,6 @@ exports.init = function (options) {
     }
     // Check if build-time update
     if (!nativeOptions.dist) {
-        // if the dist is already explicitly passed in, use that, otherwise:
         if (manifest.revisionId) {
             nativeOptions.dist = manifest.version;
         }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -65,7 +65,6 @@ export const init = (options: SentryExpoNativeOptions = {}) => {
 
   // Check if build-time update
   if (!nativeOptions.dist) {
-    // if the dist is already explicitly passed in, use that, otherwise:
     if (manifest.revisionId) {
       nativeOptions.dist = manifest.version;
     } else {

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -64,10 +64,13 @@ export const init = (options: SentryExpoNativeOptions = {}) => {
   }
 
   // Check if build-time update
-  nativeOptions.dist =
-    nativeOptions.dist || manifest.revisionId
-      ? manifest.version
-      : `${Constants.nativeBuildVersion}`;
-
+  if (!nativeOptions.dist) {
+    // if the dist is already explicitly passed in, use that, otherwise:
+    if (manifest.revisionId) {
+      nativeOptions.dist = manifest.version;
+    } else {
+      nativeOptions.dist = `${Constants.nativeBuildVersion}`;
+    }
+  }
   return initNative({ ...nativeOptions });
 };


### PR DESCRIPTION
This was confusing for me, since the `dist` value I actually passed in was not used, and it instead opted to use `manifest.version`. This is fine if I remember to keep both in sync, but also feels weird.

If I'm initializing Sentry with a specific `dist`, shouldn't it use that?