### PR TITLE
Only disable Sentry in bare workflow in development explicitly.

### DIFF
--- a/dist/sentry.js
+++ b/dist/sentry.js
@@ -90,7 +90,7 @@ exports.init = function (options) {
         nativeOptions.release = manifest.revisionId ? manifest.revisionId : defaultSentryReleaseName;
     }
     // Bail out automatically if the app isn't deployed
-    if (!manifest.revisionId && !nativeOptions.enableInExpoDevelopment) {
+    if (__DEV__ && !nativeOptions.enableInExpoDevelopment) {
         nativeOptions.enabled = false;
         console.log('[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });');
     }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -55,8 +55,10 @@ export const init = (options: SentryExpoNativeOptions = {}) => {
     nativeOptions.release = manifest.revisionId ? manifest.revisionId : defaultSentryReleaseName;
   }
 
+  
+
   // Bail out automatically if the app isn't deployed
-  if (!manifest.revisionId && !nativeOptions.enableInExpoDevelopment) {
+  if (__DEV__ && !nativeOptions.enableInExpoDevelopment) {
     nativeOptions.enabled = false;
     console.log(
       '[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });'


### PR DESCRIPTION
It's possible not to set the `enableInExpoDevelopment: true` flag, and then upload/release a build on the appstore and have Sentry be disabled if the build wasn't "published" or "exported" yet.

This only disables Sentry in development if that flag is actually false, and enables Sentry by default in production, unless explictly disabled.

My use case for this one is:
1. Bare Workflow + Self hosting the bundles and uploading them in a post-export hook.
2. I create my app, without having set the `enableInExpoDevelopment` flag.
3. I build/upload it to TestFlight.
4. I do not export any bundles to my self-hosted site yet (since there's no changes against the base bundle in TestFlight), so there is no revisionId/manifest.
5. Sentry is disabled in production b/c `enableInExpoDevelopment` is not set, which feels weird. 