### PR TITLE
Replace file directory stack frames and don't replace native code frames

### DIFF
--- a/dist/sentry.expo.js
+++ b/dist/sentry.expo.js
@@ -106,8 +106,15 @@ exports.init = function (options) {
 function isPublishedExpoUrl(url) {
     return url.includes('https://d1wp6m56sqw74a.cloudfront.net');
 }
+/**
+ * Filenames such as
+ * `/data/user/0/host.exp.exponent/files/.expo-internal/bundle-AD3BEBE4AD9CFD8AF700EE807D2762758B2A1DA0D7FAA79A285D9BF25CC3A361`
+ */
+function isLocalBundleFile(url) {
+    return !url.endsWith('.js') && url !== '[native code]';
+}
 function normalizeUrl(url) {
-    if (isPublishedExpoUrl(url)) {
+    if (isPublishedExpoUrl(url) || isLocalBundleFile(url)) {
         return react_native_1.Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
     }
     else {

--- a/dist/sentry.js
+++ b/dist/sentry.js
@@ -61,7 +61,7 @@ exports.init = function (options) {
         new bare_1.ExpoIntegration(),
         new integrations_1.RewriteFrames({
             iteratee: function (frame) {
-                if (frame.filename) {
+                if (frame.filename && frame.filename !== '[native code]') {
                     frame.filename =
                         react_native_1.Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
                 }

--- a/src/sentry.expo.ts
+++ b/src/sentry.expo.ts
@@ -78,8 +78,16 @@ function isPublishedExpoUrl(url: string) {
   return url.includes('https://d1wp6m56sqw74a.cloudfront.net');
 }
 
+/**
+ * Filenames such as 
+ * `/data/user/0/host.exp.exponent/files/.expo-internal/bundle-AD3BEBE4AD9CFD8AF700EE807D2762758B2A1DA0D7FAA79A285D9BF25CC3A361`
+ */
+function isLocalBundleFile(url: string) {
+  return !url.endsWith('.js') && url !== '[native code]'
+}
+
 function normalizeUrl(url: string) {
-  if (isPublishedExpoUrl(url)) {
+  if (isPublishedExpoUrl(url) || isLocalBundleFile(url)) {
     return Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
   } else {
     return url;

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -20,7 +20,7 @@ export const init = (options: SentryExpoNativeOptions = {}) => {
     new ExpoIntegration(),
     new RewriteFrames({
       iteratee: (frame) => {
-        if (frame.filename) {
+        if (frame.filename && frame.filename !== '[native code]') {
           frame.filename =
             Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
         }


### PR DESCRIPTION
Replace file-directory-bundle stack frame filenames, and also don't replace `[native code]` frames. With this [upstream fix](https://github.com/getsentry/sentry-javascript/pull/3070) applied in `@sentry/browser`, these frames weren't getting replaced which causes source maps to not be applied.

Fixes https://github.com/getsentry/sentry-react-native/issues/1116