### PR TITLE
Hide log if option is already known

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -81,9 +81,12 @@ export const init = (options: SentryExpoNativeOptions = {}) => {
 
   if (__DEV__ && !nativeOptions.enableInExpoDevelopment) {
     nativeOptions.enabled = false;
-    console.log(
-      '[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });'
-    );
+
+    if (typeof nativeOptions.enableInExpoDevelopment === 'undefined') {
+      console.log(
+        '[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });'
+      );
+    }
   }
 
   try {

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -81,7 +81,6 @@ export const init = (options: SentryExpoNativeOptions = {}) => {
 
   if (__DEV__ && !nativeOptions.enableInExpoDevelopment) {
     nativeOptions.enabled = false;
-
     if (!nativeOptions.hasOwnProperty('enableInExpoDevelopment')) {
       console.log(
         '[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });'

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -82,7 +82,7 @@ export const init = (options: SentryExpoNativeOptions = {}) => {
   if (__DEV__ && !nativeOptions.enableInExpoDevelopment) {
     nativeOptions.enabled = false;
 
-    if (typeof nativeOptions.enableInExpoDevelopment === 'undefined') {
+    if (!nativeOptions.hasOwnProperty('enableInExpoDevelopment')) {
       console.log(
         '[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });'
       );


### PR DESCRIPTION
# Why?
While running `yarn start`, I always see the console log:

```
[sentry-expo] Disabled Sentry in development. Note you can set Sentry.init({ enableInExpoDevelopment: true });
```

I think this log should not be shown if I already set `enableInExpoDevelopment` (to `true` or `false`).

I have this code in my project:

```
import * as Sentry from 'sentry-expo';
import Constants from 'expo-constants';

Sentry.init({
  dsn: 'xxxx',
  enableInExpoDevelopment: false,
  release: Constants.manifest.revisionId,
});
```

As you can see, I'm already aware of the existance of `enableInExpoDevelopment`, so, the warning is unnecessary.

Not sure if `typeof xxx...` is the way to go here. I don't have context about TypeScript. Let me know if there is a cleaner way, I can change it.