### PR TITLE
fix: get `deviceYearClass` from `expo-device`

### DIFF
--- a/src/integrations/bare.ts
+++ b/src/integrations/bare.ts
@@ -45,7 +45,9 @@ export class ExpoBareIntegration {
     });
 
     DEFAULT_EXTRAS.forEach((extra) => {
-      if (Constants.hasOwnProperty(extra)) {
+      if (Object.hasOwnProperty.call(Device, extra)) {
+        setExtra(extra, Device[extra]);
+      } else if (Object.hasOwnProperty.call(Constants, extra)) {
         setExtra(extra, Constants[extra]);
       }
     });

--- a/src/integrations/managed.ts
+++ b/src/integrations/managed.ts
@@ -45,7 +45,9 @@ export class ExpoManagedIntegration {
     });
 
     DEFAULT_EXTRAS.forEach((extra) => {
-      if (Constants.hasOwnProperty(extra)) {
+      if (Object.hasOwnProperty.call(Device, extra)) {
+        setExtra(extra, Device[extra]);
+      } else if (Object.hasOwnProperty.call(Constants, extra)) {
         setExtra(extra, Constants[extra]);
       }
     });


### PR DESCRIPTION
Upgrading to SDK 43 prints `Constants.deviceYearClass has been deprecated in favor of expo-device's Device.deviceYearClass property. This API will be removed in SDK 45.`

(I made this change in GH's UI, so I'm unable to update the build files)