### PR TITLE
Fix build phase script on iOS

### DIFF
--- a/plugin/src/withSentryIOS.ts
+++ b/plugin/src/withSentryIOS.ts
@@ -66,7 +66,7 @@ export function modifyExistingXcodeBuildScript(script: any): void {
     code.replace(
       /^.*?(packager|scripts)\/react-native-xcode\.sh\s*(\\'\\\\")?/m,
       (match: any) =>
-        "`node --print \"require.resolve('@sentry/cli/package.json').slice(0, -13) + '/bin/sentry-cli'\"` react-native xcode --force-foreground\n" +
+        "`node --print \"require.resolve('@sentry/cli/package.json').slice(0, -13) + '/bin/sentry-cli'\"` react-native xcode --force-foreground " +
         match
     );
 


### PR DESCRIPTION
There should not be a line break between sentry-cli call and the package script. See https://docs.sentry.io/platforms/react-native/manual-setup/manual-setup/#bundle-react-native-code-and-images. Note the backslash in the instructions that escapes the line break. Here we can just use a space instead and keep everything on the same line.