### PR TITLE
fix: warning on expo 46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix issue with config plugin being unable to modify Android gradle file with Expo 46
+
 ### 🧹 Chores
 
 ## [5.0.2](https://github.com/expo/sentry-expo/releases/tag/v5.0.2) - 2022-08-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix issue with config plugin being unable to modify Android gradle file with Expo 46
+- Fix issue with config plugin being unable to modify Android gradle file with Expo 46. ([#283](https://github.com/expo/sentry-expo/pull/283) by [@stezu](https://github.com/stezu))
 
 ### 🧹 Chores
 

--- a/plugin/src/withSentryAndroid.ts
+++ b/plugin/src/withSentryAndroid.ts
@@ -41,7 +41,7 @@ export function modifyAppBuildGradle(buildGradle: string) {
   if (buildGradle.includes('/sentry.gradle"')) {
     return buildGradle;
   }
-  const pattern = /(.*\/react\.gradle"\)?)(\s|\n|$)/;
+  const pattern = /(.*(\/|")react\.gradle"\)?)(\s|\n|$)/;
 
   if (!buildGradle.match(pattern)) {
     WarningAggregator.addWarningAndroid(


### PR DESCRIPTION
# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/sentry-expo/blob/main/CHANGELOG.md#master) if necessary.

# Why

Fixes an issue present with Expo 46 (also documented in #279) where the `react.gradle` import is now:
```ts
apply from: new File(reactNativeRoot, "react.gradle")
```

The previous regular expression was expecting a `/` character before the `react.gradle` string and was not matching this new import string.

# How

The regular expression was updated to support both the old import style and the new one.

# Test Plan

The change was used to run `expo prebuild` locally on a project upgraded to expo 46 and the `build.gradle` validated to ensure the sentry change was successfully applied.