### PR TITLE
[plugin] update android script injection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Update Android script injection logic ([#322](https://github.com/expo/sentry-expo/pull/322) by [@kbrandwijk](https://github.com/kbrandwijk))
+
 ### 🧹 Chores
 
 ## [6.0.0](https://github.com/expo/sentry-expo/releases/tag/v6.0.0) - 2022-11-24

--- a/plugin/build/withSentryAndroid.d.ts
+++ b/plugin/build/withSentryAndroid.d.ts
@@ -3,7 +3,5 @@ export declare const withSentryAndroid: ConfigPlugin<string>;
 /**
  * Writes to projectDirectory/android/app/build.gradle,
  * adding the relevant @sentry/react-native script.
- *
- * We can be confident that the react-native/react.gradle script will be there.
  */
 export declare function modifyAppBuildGradle(buildGradle: string): string;

--- a/plugin/build/withSentryAndroid.js
+++ b/plugin/build/withSentryAndroid.js
@@ -49,8 +49,6 @@ exports.withSentryAndroid = withSentryAndroid;
 /**
  * Writes to projectDirectory/android/app/build.gradle,
  * adding the relevant @sentry/react-native script.
- *
- * We can be confident that the react-native/react.gradle script will be there.
  */
 function modifyAppBuildGradle(buildGradle) {
     if (buildGradle.includes('/sentry.gradle"')) {

--- a/plugin/build/withSentryAndroid.js
+++ b/plugin/build/withSentryAndroid.js
@@ -63,6 +63,6 @@ function modifyAppBuildGradle(buildGradle) {
         config_plugins_1.WarningAggregator.addWarningAndroid('sentry-expo', 'Could not find react.gradle script in android/app/build.gradle. Please open a bug report at https://github.com/expo/sentry-expo.');
     }
     const applyFrom = `apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")`;
-    return buildGradle.replace(pattern, match => applyFrom + '\n' + match);
+    return buildGradle.replace(pattern, match => applyFrom + '\n\n' + match);
 }
 exports.modifyAppBuildGradle = modifyAppBuildGradle;

--- a/plugin/build/withSentryAndroid.js
+++ b/plugin/build/withSentryAndroid.js
@@ -56,12 +56,13 @@ function modifyAppBuildGradle(buildGradle) {
     if (buildGradle.includes('/sentry.gradle"')) {
         return buildGradle;
     }
-    const pattern = /(.*(\/|")react\.gradle"\)?)(\s|\n|$)/;
+    // Use the same location that sentry-wizard uses 
+    // See: https://github.com/getsentry/sentry-wizard/blob/e9b4522f27a852069c862bd458bdf9b07cab6e33/lib/Steps/Integrations/ReactNative.ts#L232
+    const pattern = /^android {/m;
     if (!buildGradle.match(pattern)) {
         config_plugins_1.WarningAggregator.addWarningAndroid('sentry-expo', 'Could not find react.gradle script in android/app/build.gradle. Please open a bug report at https://github.com/expo/sentry-expo.');
     }
-    return buildGradle.replace(pattern, `$1
-apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")
-`);
+    const applyFrom = `apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")`;
+    return buildGradle.replace(pattern, match => applyFrom + '\n' + match);
 }
 exports.modifyAppBuildGradle = modifyAppBuildGradle;

--- a/plugin/src/__tests__/modifyAppBuildGradle-test.ts
+++ b/plugin/src/__tests__/modifyAppBuildGradle-test.ts
@@ -11,38 +11,27 @@ jest.mock('@expo/config-plugins', () => {
 });
 
 const buildGradleWithSentry = `
-rectly from the development server. Below you can see all the possible configurations
- * and their defaults. If you decide to add a configuration block, make sure to add it before the
- * \`apply from: "../../node_modules/react-native/react.gradle"\` line.
- *
-apply from: "../../node_modules/react-native/react.gradle"
 apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")
+
+android {
+}
 `;
 
 const buildGradleWithOutSentry = `
-rectly from the development server. Below you can see all the possible configurations
- * and their defaults. If you decide to add a configuration block, make sure to add it before the
- * \`apply from: "../../node_modules/react-native/react.gradle"\` line.
- *
-apply from: "../../node_modules/react-native/react.gradle"
-
+android {
+}
 `;
 
 const monoRepoBuildGradleWithSentry = `
-rectly from the development server. Below you can see all the possible configurations
- * and their defaults. If you decide to add a configuration block, make sure to add it before the
- * \`apply from: "../../node_modules/react-native/react.gradle"\` line.
- *
-apply from: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute().text.trim(), "../react.gradle")
 apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")
+
+android {
+}
 `;
 
 const monoRepoBuildGradleWithOutSentry = `
-rectly from the development server. Below you can see all the possible configurations
- * and their defaults. If you decide to add a configuration block, make sure to add it before the
- * \`apply from: "../../node_modules/react-native/react.gradle"\` line.
- *
-apply from: new File(["node", "--print", "require.resolve('react-native/package.json')"].execute().text.trim(), "../react.gradle")
+android {
+}
 `;
 
 const buildGradleWithOutReactGradleScript = `

--- a/plugin/src/withSentryAndroid.ts
+++ b/plugin/src/withSentryAndroid.ts
@@ -34,8 +34,6 @@ export const withSentryAndroid: ConfigPlugin<string> = (config, sentryProperties
 /**
  * Writes to projectDirectory/android/app/build.gradle,
  * adding the relevant @sentry/react-native script.
- *
- * We can be confident that the react-native/react.gradle script will be there.
  */
 export function modifyAppBuildGradle(buildGradle: string) {
   if (buildGradle.includes('/sentry.gradle"')) {

--- a/plugin/src/withSentryAndroid.ts
+++ b/plugin/src/withSentryAndroid.ts
@@ -57,6 +57,6 @@ export function modifyAppBuildGradle(buildGradle: string) {
   
   return buildGradle.replace(
     pattern,
-    match => applyFrom + '\n' + match
+    match => applyFrom + '\n\n' + match
   );
 }

--- a/plugin/src/withSentryAndroid.ts
+++ b/plugin/src/withSentryAndroid.ts
@@ -41,7 +41,10 @@ export function modifyAppBuildGradle(buildGradle: string) {
   if (buildGradle.includes('/sentry.gradle"')) {
     return buildGradle;
   }
-  const pattern = /(.*(\/|")react\.gradle"\)?)(\s|\n|$)/;
+  
+  // Use the same location that sentry-wizard uses 
+  // See: https://github.com/getsentry/sentry-wizard/blob/e9b4522f27a852069c862bd458bdf9b07cab6e33/lib/Steps/Integrations/ReactNative.ts#L232
+  const pattern = /^android {/m;
 
   if (!buildGradle.match(pattern)) {
     WarningAggregator.addWarningAndroid(
@@ -50,10 +53,10 @@ export function modifyAppBuildGradle(buildGradle: string) {
     );
   }
 
+  const applyFrom = 'apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")'
+  
   return buildGradle.replace(
     pattern,
-    `$1
-apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")
-`
+    match => applyFrom + '\n' + match
   );
 }

--- a/plugin/src/withSentryAndroid.ts
+++ b/plugin/src/withSentryAndroid.ts
@@ -53,7 +53,7 @@ export function modifyAppBuildGradle(buildGradle: string) {
     );
   }
 
-  const applyFrom = 'apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")'
+  const applyFrom = `apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")`;
   
   return buildGradle.replace(
     pattern,


### PR DESCRIPTION
<!-- Thanks for contributing to _sentry-expo_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/sentry-expo/blob/main/CHANGELOG.md#master) if necessary.

# Why

The app/build.gradle template changed in RN 0.71, breaking the sentry script injection because the old injection point doesn't exist anymore. 

# How

This change opts for a safer injection point, that is backwards compatible, and matches the sentry-wizard implementation.

# Test Plan

Local testing, the result is as expected, in app/build.gradle:

```gradle
apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")

android {
```