### PR TITLE
Remove json as an option for setting authToken

### DIFF
--- a/src/hooks/upload-sourcemaps.ts
+++ b/src/hooks/upload-sourcemaps.ts
@@ -64,10 +64,10 @@ module.exports = async (options: Options) => {
     }
 
     const childProcessEnv = Object.assign({}, process.env, {
-      SENTRY_ORG: (config && config.organization) || process.env.SENTRY_ORG,
-      SENTRY_PROJECT: (config && config.project) || process.env.SENTRY_PROJECT,
-      SENTRY_AUTH_TOKEN: (config && config.authToken) || process.env.SENTRY_AUTH_TOKEN,
-      SENTRY_URL: (config && config.url) || process.env.SENTRY_URL || 'https://sentry.io/',
+      SENTRY_ORG: process.env.SENTRY_ORG,
+      SENTRY_PROJECT: process.env.SENTRY_PROJECT,
+      SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
+      SENTRY_URL: process.env.SENTRY_URL || 'https://sentry.io/',
     });
 
     const uploadOptions = getUploadOptions(config, process.env, iosManifest);
@@ -75,7 +75,7 @@ module.exports = async (options: Options) => {
   } catch (e) {
     log(messageForError(e));
     log(
-      `Verify that your Sentry configuration in app.json is correct and refer to https://docs.expo.io/versions/latest/guides/using-sentry.html`
+      `Verify that you have correctly set the environment variables - SENTRY_* - and refer to https://docs.expo.io/versions/latest/guides/using-sentry.html`
     );
   } finally {
     rimraf.sync(tmpdir);


### PR DESCRIPTION
<!-- Thanks for contributing to _sentry-expo_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [ ] I've added an entry to [CHANGELOG.md](https://github.com/expo/sentry-expo/blob/main/CHANGELOG.md#master) if necessary.

# Why

Breaking Change - Security - this removes sentry authToken from the app.json file

# How

AuthToken shouldn't be made public.

# Test Plan

You can try setting the authToken in the json and it shouldn't work...it will only work from the environment variables.