### PR TITLE
fix: discourage `authToken` usage and link to updated docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Discourage configuring `authToken` and point to `SENTRY_AUTH_TOKEN` and docs. ([#325](https://github.com/expo/sentry-expo/pull/325) by [@byCedric](https://github.com/byCedric))
+
 ### 🧹 Chores
 
 ## [6.1.0](https://github.com/expo/sentry-expo/releases/tag/v6.1.0) - 2023-03-04

--- a/plugin/build/withSentry.js
+++ b/plugin/build/withSentry.js
@@ -23,7 +23,7 @@ const withSentry = (config) => {
     }
     return config;
 };
-const missingAuthTokenMessage = `# no auth.token found, falling back to SENTRY_AUTH_TOKEN environment variable`;
+const missingAuthTokenMessage = `# Configured through SENTRY_AUTH_TOKEN environment variable`;
 const missingProjectMessage = `# no project found, falling back to SENTRY_PROJECT environment variable`;
 const missingOrgMessage = `# no org found, falling back to SENTRY_ORG environment variable`;
 function getSentryProperties(config) {
@@ -62,7 +62,7 @@ function buildSentryPropertiesString(sentryHookConfig) {
     return `defaults.url=${url}
 ${organization ? `defaults.org=${organization}` : missingOrgMessage}
 ${project ? `defaults.project=${project}` : missingProjectMessage}
-${authToken ? `auth.token=${authToken}` : missingAuthTokenMessage}
+${authToken ? `# Configure this value through \`SENTRY_AUTH_TOKEN\` environment variable instead. See:https://docs.expo.dev/guides/using-sentry/#app-configuration\nauth.token=${authToken}` : missingAuthTokenMessage}
 `;
 }
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withSentry, pkg.name, pkg.version);

--- a/plugin/build/withSentry.js
+++ b/plugin/build/withSentry.js
@@ -23,7 +23,7 @@ const withSentry = (config) => {
     }
     return config;
 };
-const missingAuthTokenMessage = `# Configured through SENTRY_AUTH_TOKEN environment variable`;
+const missingAuthTokenMessage = `# auth.token is configured through SENTRY_AUTH_TOKEN environment variable`;
 const missingProjectMessage = `# no project found, falling back to SENTRY_PROJECT environment variable`;
 const missingOrgMessage = `# no org found, falling back to SENTRY_ORG environment variable`;
 function getSentryProperties(config) {
@@ -48,12 +48,7 @@ function getSentryProperties(config) {
 exports.getSentryProperties = getSentryProperties;
 function buildSentryPropertiesString(sentryHookConfig) {
     const { organization, project, authToken, url = 'https://sentry.io/' } = sentryHookConfig ?? {};
-    const missingProperties = ['organization', 'project', 'authToken'].filter((each) => {
-        if (!sentryHookConfig?.hasOwnProperty(each)) {
-            return true;
-        }
-        return false;
-    });
+    const missingProperties = ['organization', 'project'].filter((each) => !sentryHookConfig?.hasOwnProperty(each));
     if (missingProperties.length) {
         const warningMessage = `Missing Sentry configuration properties: ${missingProperties.join(', ')} from app.json. Builds will fall back to environment variables. Refer to @sentry/react-native docs for how to configure this.`;
         config_plugins_1.WarningAggregator.addWarningAndroid('sentry-expo', warningMessage);

--- a/plugin/build/withSentry.js
+++ b/plugin/build/withSentry.js
@@ -39,6 +39,10 @@ function getSentryProperties(config) {
         config_plugins_1.WarningAggregator.addWarningIOS('sentry-expo', 'No Sentry config found in app.json, builds will fall back to environment variables. Refer to @sentry/react-native docs for how to configure this.');
         return '';
     }
+    if (sentryHook.config?.authToken) {
+        config_plugins_1.WarningAggregator.addWarningAndroid('sentry-expo', 'Sentry `authToken` found in app.json. Avoid committing this value to your repository, configure it through `SENTRY_AUTH_TOKEN` environment variable instead. See: https://docs.expo.dev/guides/using-sentry/#app-configuration');
+        config_plugins_1.WarningAggregator.addWarningIOS('sentry-expo', 'Sentry `authToken` found in app.json. Avoid committing this value to your repository, configure it through `SENTRY_AUTH_TOKEN` environment variable instead. See: https://docs.expo.dev/guides/using-sentry/#app-configuration');
+    }
     return buildSentryPropertiesString(sentryHook.config);
 }
 exports.getSentryProperties = getSentryProperties;

--- a/plugin/src/__tests__/getSentryProperties-test.ts
+++ b/plugin/src/__tests__/getSentryProperties-test.ts
@@ -155,6 +155,7 @@ describe('Get Sentry properties from app config', () => {
       `defaults.url=https://sentry.io/
 defaults.org=test-org
 defaults.project=myProjectName
+# Configure this value through \`SENTRY_AUTH_TOKEN\` environment variable instead. See:https://docs.expo.dev/guides/using-sentry/#app-configuration
 auth.token=123-abc
 `
     );
@@ -170,6 +171,7 @@ auth.token=123-abc
       `defaults.url=https://sentry.io/
 defaults.org=test-org
 defaults.project=myProjectName
+# Configure this value through \`SENTRY_AUTH_TOKEN\` environment variable instead. See:https://docs.expo.dev/guides/using-sentry/#app-configuration
 auth.token=123-abc
 `
     );
@@ -180,7 +182,7 @@ auth.token=123-abc
       `defaults.url=some-url
 # no org found, falling back to SENTRY_ORG environment variable
 # no project found, falling back to SENTRY_PROJECT environment variable
-# no auth.token found, falling back to SENTRY_AUTH_TOKEN environment variable
+# auth.token is configured through SENTRY_AUTH_TOKEN environment variable
 `
     );
   });
@@ -190,7 +192,7 @@ auth.token=123-abc
       `defaults.url=some-url
 # no org found, falling back to SENTRY_ORG environment variable
 # no project found, falling back to SENTRY_PROJECT environment variable
-# no auth.token found, falling back to SENTRY_AUTH_TOKEN environment variable
+# auth.token is configured through SENTRY_AUTH_TOKEN environment variable
 `
     );
   });

--- a/plugin/src/withSentry.ts
+++ b/plugin/src/withSentry.ts
@@ -71,12 +71,8 @@ export function getSentryProperties(config: ExpoConfig): string | null {
 
 function buildSentryPropertiesString(sentryHookConfig: PublishHook['config']) {
   const { organization, project, authToken, url = 'https://sentry.io/' } = sentryHookConfig ?? {};
-  const missingProperties = ['organization', 'project', 'authToken'].filter((each) => {
-    if (!sentryHookConfig?.hasOwnProperty(each)) {
-      return true
-    }
-    return false
-  });
+  const missingProperties = ['organization', 'project'].filter((each) => !sentryHookConfig?.hasOwnProperty(each));
+
   if (missingProperties.length) {
     const warningMessage = `Missing Sentry configuration properties: ${missingProperties.join(
       ', '
@@ -84,6 +80,7 @@ function buildSentryPropertiesString(sentryHookConfig: PublishHook['config']) {
     WarningAggregator.addWarningAndroid('sentry-expo', warningMessage);
     WarningAggregator.addWarningIOS('sentry-expo', warningMessage);
   }
+
   return `defaults.url=${url}
 ${organization ? `defaults.org=${organization}` : missingOrgMessage}
 ${project ? `defaults.project=${project}` : missingProjectMessage}

--- a/plugin/src/withSentry.ts
+++ b/plugin/src/withSentry.ts
@@ -55,6 +55,17 @@ export function getSentryProperties(config: ExpoConfig): string | null {
     return '';
   }
 
+  if (sentryHook.config?.authToken) {
+    WarningAggregator.addWarningAndroid(
+      'sentry-expo',
+      'Sentry `authToken` found in app.json. Avoid committing this value to your repository, configure it through `SENTRY_AUTH_TOKEN` environment variable instead. See: https://docs.expo.dev/guides/using-sentry/#app-configuration'
+    );
+    WarningAggregator.addWarningIOS(
+      'sentry-expo',
+      'Sentry `authToken` found in app.json. Avoid committing this value to your repository, configure it through `SENTRY_AUTH_TOKEN` environment variable instead. See: https://docs.expo.dev/guides/using-sentry/#app-configuration'
+    );
+  }
+
   return buildSentryPropertiesString(sentryHook.config);
 }
 

--- a/plugin/src/withSentry.ts
+++ b/plugin/src/withSentry.ts
@@ -30,7 +30,7 @@ const withSentry: ConfigPlugin = (config) => {
   return config;
 };
 
-const missingAuthTokenMessage = `# no auth.token found, falling back to SENTRY_AUTH_TOKEN environment variable`;
+const missingAuthTokenMessage = `# auth.token is configured through SENTRY_AUTH_TOKEN environment variable`;
 const missingProjectMessage = `# no project found, falling back to SENTRY_PROJECT environment variable`;
 const missingOrgMessage = `# no org found, falling back to SENTRY_ORG environment variable`;
 
@@ -87,7 +87,7 @@ function buildSentryPropertiesString(sentryHookConfig: PublishHook['config']) {
   return `defaults.url=${url}
 ${organization ? `defaults.org=${organization}` : missingOrgMessage}
 ${project ? `defaults.project=${project}` : missingProjectMessage}
-${authToken ? `auth.token=${authToken}` : missingAuthTokenMessage}
+${authToken ? `# Configure this value through \`SENTRY_AUTH_TOKEN\` environment variable instead. See:https://docs.expo.dev/guides/using-sentry/#app-configuration\nauth.token=${authToken}` : missingAuthTokenMessage}
 `;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _sentry-expo_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/sentry-expo/blob/main/CHANGELOG.md#master) if necessary.

# Why

See #321 

# How

Added a warning whenever you configure `authToken` through the post-publish hook.

# Test Plan

- `$ yarn create expo-app ./test-authtoken`
- `$ cd ./test-authtoken`
- `$ yarn expo install sentry-expo`
- Configure `app.json` with the post-publish token, including `authToken`
- `$ yarn expo prebuild`
- Warning should be visible
