### PR TITLE
fix: Dynamically resolve `collectModulesScript` script path to support monorepos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Dynamically resolve `collectModulesScript` script path to support monorepos.
+
 ### 🧹 Chores
 
 ## [6.2.1](https://github.com/expo/sentry-expo/releases/tag/v6.2.1) - 2023-06-07

--- a/plugin/build/withSentryAndroid.js
+++ b/plugin/build/withSentryAndroid.js
@@ -46,6 +46,7 @@ const withSentryAndroid = (config, sentryProperties) => {
     ]);
 };
 exports.withSentryAndroid = withSentryAndroid;
+const resolveSentryReactNativePackageJsonPath = `["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim()`;
 /**
  * Writes to projectDirectory/android/app/build.gradle,
  * adding the relevant @sentry/react-native script.
@@ -60,7 +61,8 @@ function modifyAppBuildGradle(buildGradle) {
     if (!buildGradle.match(pattern)) {
         config_plugins_1.WarningAggregator.addWarningAndroid('sentry-expo', 'Could not find react.gradle script in android/app/build.gradle. Please open a bug report at https://github.com/expo/sentry-expo.');
     }
-    const applyFrom = `apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")`;
-    return buildGradle.replace(pattern, match => applyFrom + '\n\n' + match);
+    const sentryOptions = `project.ext.sentryCli=[collectModulesScript: new File(${resolveSentryReactNativePackageJsonPath}, "../dist/js/tools/collectModules.js")]`;
+    const applyFrom = `apply from: new File(${resolveSentryReactNativePackageJsonPath}, "../sentry.gradle")`;
+    return buildGradle.replace(pattern, match => sentryOptions + '\n\n' + applyFrom + '\n\n' + match);
 }
 exports.modifyAppBuildGradle = modifyAppBuildGradle;

--- a/plugin/build/withSentryAndroid.js
+++ b/plugin/build/withSentryAndroid.js
@@ -61,7 +61,9 @@ function modifyAppBuildGradle(buildGradle) {
     if (!buildGradle.match(pattern)) {
         config_plugins_1.WarningAggregator.addWarningAndroid('sentry-expo', 'Could not find react.gradle script in android/app/build.gradle. Please open a bug report at https://github.com/expo/sentry-expo.');
     }
-    const sentryOptions = `project.ext.sentryCli=[collectModulesScript: new File(${resolveSentryReactNativePackageJsonPath}, "../dist/js/tools/collectModules.js")]`;
+    const sentryOptions = !buildGradle.includes('project.ext.sentryCli')
+        ? `project.ext.sentryCli=[collectModulesScript: new File(${resolveSentryReactNativePackageJsonPath}, "../dist/js/tools/collectModules.js")]`
+        : '';
     const applyFrom = `apply from: new File(${resolveSentryReactNativePackageJsonPath}, "../sentry.gradle")`;
     return buildGradle.replace(pattern, match => sentryOptions + '\n\n' + applyFrom + '\n\n' + match);
 }

--- a/plugin/src/withSentryAndroid.ts
+++ b/plugin/src/withSentryAndroid.ts
@@ -31,6 +31,8 @@ export const withSentryAndroid: ConfigPlugin<string> = (config, sentryProperties
   ]);
 };
 
+const resolveSentryReactNativePackageJsonPath = `["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim()`;
+
 /**
  * Writes to projectDirectory/android/app/build.gradle,
  * adding the relevant @sentry/react-native script.
@@ -51,10 +53,11 @@ export function modifyAppBuildGradle(buildGradle: string) {
     );
   }
 
-  const applyFrom = `apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")`;
+  const sentryOptions = `project.ext.sentryCli=[collectModulesScript: new File(${resolveSentryReactNativePackageJsonPath}, "../dist/js/tools/collectModules.js")]`;
+  const applyFrom = `apply from: new File(${resolveSentryReactNativePackageJsonPath}, "../sentry.gradle")`;
   
   return buildGradle.replace(
     pattern,
-    match => applyFrom + '\n\n' + match
+    match => sentryOptions + '\n\n' + applyFrom + '\n\n' + match
   );
 }

--- a/plugin/src/withSentryAndroid.ts
+++ b/plugin/src/withSentryAndroid.ts
@@ -53,7 +53,9 @@ export function modifyAppBuildGradle(buildGradle: string) {
     );
   }
 
-  const sentryOptions = `project.ext.sentryCli=[collectModulesScript: new File(${resolveSentryReactNativePackageJsonPath}, "../dist/js/tools/collectModules.js")]`;
+  const sentryOptions = !buildGradle.includes('project.ext.sentryCli')
+    ? `project.ext.sentryCli=[collectModulesScript: new File(${resolveSentryReactNativePackageJsonPath}, "../dist/js/tools/collectModules.js")]`
+    : '';
   const applyFrom = `apply from: new File(${resolveSentryReactNativePackageJsonPath}, "../sentry.gradle")`;
   
   return buildGradle.replace(


### PR DESCRIPTION
Thanks to @anirudhsama and @maximgeerinck for the original [workaround](https://github.com/expo/sentry-expo/issues/292#issuecomment-1544211475).
<!-- Thanks for contributing to _sentry-expo_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/sentry-expo/blob/main/CHANGELOG.md#master) if necessary.

# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
closes: https://github.com/expo/sentry-expo/issues/342

# How

How did you build this feature or fix this bug and why?

This is already fixed in `sentry-react-native`. But until released and upgraded here, this PR will work for all the versions.
https://github.com/getsentry/sentry-react-native/pull/3092

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

Sample app and other users from https://github.com/expo/sentry-expo/issues/342
