### PR TITLE
Use NODE_BINARY as per https://github.com/getsentry/sentry-react-native/pull/2805

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use NODE_BINARY as per https://github.com/getsentry/sentry-react-native/pull/2805
+
 ### 🧹 Chores
 
 ## [7.1.1](https://github.com/expo/sentry-expo/releases/tag/v7.1.1) - 2023-10-18

--- a/plugin/build/withSentryIOS.js
+++ b/plugin/build/withSentryIOS.js
@@ -27,7 +27,7 @@ exports.writeSentryPropertiesTo = exports.modifyExistingXcodeBuildScript = expor
 const config_plugins_1 = require("expo/config-plugins");
 const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
-const SENTRY_CLI = `\`node --print "require.resolve('@sentry/cli/package.json').slice(0, -13) + '/bin/sentry-cli'"\``;
+const SENTRY_CLI = `\`$NODE_BINARY --print "require.resolve('@sentry/cli/package.json').slice(0, -13) + '/bin/sentry-cli'"\``;
 const withSentryIOS = (config, sentryProperties) => {
     config = (0, config_plugins_1.withXcodeProject)(config, (config) => {
         const xcodeProject = config.modResults;
@@ -66,7 +66,7 @@ function modifyExistingXcodeBuildScript(script) {
         'export SENTRY_PROPERTIES=sentry.properties\n' +
             'export EXTRA_PACKAGER_ARGS="--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map"\n' +
             code.replace(/^.*?(packager|scripts)\/react-native-xcode\.sh\s*(\\'\\\\")?/m, (match) => `${SENTRY_CLI} react-native xcode --force-foreground ${match}`) +
-            "\n\n`node --print \"require.resolve('@sentry/react-native/package.json').slice(0, -13) + '/scripts/collect-modules.sh'\"`";
+            "\n\n`$NODE_BINARY --print \"require.resolve('@sentry/react-native/package.json').slice(0, -13) + '/scripts/collect-modules.sh'\"`";
     script.shellScript = JSON.stringify(code);
 }
 exports.modifyExistingXcodeBuildScript = modifyExistingXcodeBuildScript;

--- a/plugin/src/withSentryIOS.ts
+++ b/plugin/src/withSentryIOS.ts
@@ -7,7 +7,7 @@ import {
 import * as fs from 'fs';
 import * as path from 'path';
 
-const SENTRY_CLI = `\`node --print "require.resolve('@sentry/cli/package.json').slice(0, -13) + '/bin/sentry-cli'"\``;
+const SENTRY_CLI = `\`$NODE_BINARY --print "require.resolve('@sentry/cli/package.json').slice(0, -13) + '/bin/sentry-cli'"\``;
 
 export const withSentryIOS: ConfigPlugin<string> = (config, sentryProperties: string) => {
   config = withXcodeProject(config, (config) => {
@@ -71,7 +71,7 @@ export function modifyExistingXcodeBuildScript(script: any): void {
       /^.*?(packager|scripts)\/react-native-xcode\.sh\s*(\\'\\\\")?/m,
       (match: any) => `${SENTRY_CLI} react-native xcode --force-foreground ${match}`
     ) +
-    "\n\n`node --print \"require.resolve('@sentry/react-native/package.json').slice(0, -13) + '/scripts/collect-modules.sh'\"`";
+    "\n\n`$NODE_BINARY --print \"require.resolve('@sentry/react-native/package.json').slice(0, -13) + '/scripts/collect-modules.sh'\"`";
 
   script.shellScript = JSON.stringify(code);
 }


### PR DESCRIPTION
…

<!-- Thanks for contributing to _sentry-expo_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

# Checklist

- [x] I've added an entry to [CHANGELOG.md](https://github.com/expo/sentry-expo/blob/main/CHANGELOG.md#master) if necessary.

# Why

When running a build from XCode, if the node path is non standard (for instance set with a `nix develop` environment) the expected path should be set in `.xcode.env` or `.xcode.env.local` and scripts should use `$NODE_BINARY` instead of `node`. `@sentry/react-native` already implemented this here https://github.com/getsentry/sentry-react-native/pull/2805 so this expo wrapper should also use `$NODE_BINARY`.

# How

Replace the 2 instances of `node` by `$NODE_BINARY`.

# Test Plan

Tested locally.